### PR TITLE
[OHRI-129] - Automated deployment for Dev, Staging, Demo instances

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,13 @@ name: Node.js CI
 
 on:
   push:
-    branches: [master]
+    tags:
+      - '*'
+    branches:
+      - master
+      - staging
+      - demo
+      - dev
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, closed]
@@ -11,8 +17,8 @@ on:
       - created
 
 env:
-  ESM_NAME: "@openmrs/esm-ohri-app"
-  JS_NAME: "openmrs-esm-ohri-app.js"
+  ESM_NAME: "openmrs-esm-ohri-form"
+  JS_NAME: "openmrs-esm-ohri-form.js"
 
 jobs:
   build:
@@ -53,47 +59,48 @@ jobs:
         run: |
           mkdir -p dist/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}
           mv dist/*.* dist/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}/
-      - name: Publish to Digital Ocean
-        uses: jakejarvis/s3-sync-action@master
+      # - name: Publish to Digital Ocean
+      #   uses: jakejarvis/s3-sync-action@master
+      #   with:
+      #     args: --acl public-read --follow-symlinks --cache-control "max-age=31536000"
+      #   env:
+      #     AWS_S3_BUCKET: ${{ secrets.DIGITAL_OCEAN_SPACES_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.DIGITAL_OCEAN_SPACES_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.DIGITAL_OCEAN_SPACES_ACCESS_KEY }}
+      #     AWS_S3_ENDPOINT: ${{ secrets.DIGITAL_OCEAN_SPACES_ENDPOINT }}
+      #     SOURCE_DIR: "dist"
+      
+      # - name: Update Importmap
+      #   uses: fjogeleit/http-request-action@master
+      #   with:
+      #     url: http://${{ secrets.DEPLOYER_HOST }}/services?env=prod
+      #     method: "PATCH"
+      #     username: ${{ secrets.DEPLOYER_USERNAME }}
+      #     password: ${{ secrets.DEPLOYER_PASSWORD }}
+      #     data: '{ "service":"${{ env.ESM_NAME }}","url":"https://spa-modules.nyc3.digitaloceanspaces.com/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}/${{ env.JS_NAME }}" }'
+      #     customHeaders: '{ "Accept": "application/json", "Content-Type": "application/json" }'
+
+  pre_release:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
         with:
-          args: --acl public-read --follow-symlinks --cache-control "max-age=31536000"
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm install
+      - run: sed -i -e "s/\(\"version\":\\s\+\"\([0-9]\+\.\?\)\+\)/\1-pre.${{ github.run_number }}/" 'package.json'
+      - run: npm publish --access public --tag next
         env:
-          AWS_S3_BUCKET: ${{ secrets.DIGITAL_OCEAN_SPACES_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.DIGITAL_OCEAN_SPACES_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.DIGITAL_OCEAN_SPACES_ACCESS_KEY }}
-          AWS_S3_ENDPOINT: ${{ secrets.DIGITAL_OCEAN_SPACES_ENDPOINT }}
-          SOURCE_DIR: "dist"
-      - name: Update Importmap
-        uses: fjogeleit/http-request-action@master
-        with:
-          url: http://${{ secrets.DEPLOYER_HOST }}/services?env=prod
-          method: "PATCH"
-          username: ${{ secrets.DEPLOYER_USERNAME }}
-          password: ${{ secrets.DEPLOYER_PASSWORD }}
-          data: '{ "service":"${{ env.ESM_NAME }}","url":"https://spa-modules.nyc3.digitaloceanspaces.com/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}/${{ env.JS_NAME }}" }'
-          customHeaders: '{ "Accept": "application/json", "Content-Type": "application/json" }'
-
-#   pre_release:
-#     runs-on: ubuntu-latest
-
-#     needs: build
-
-#     if: ${{ github.event_name == 'push' }}
-
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: Download Artifacts
-#         uses: actions/download-artifact@v2
-#       - name: Use Node.js
-#         uses: actions/setup-node@v1
-#         with:
-#           node-version: "14.x"
-#           registry-url: "https://registry.npmjs.org"
-#       - run: npm install
-#       - run: sed -i -e "s/\(\"version\":\\s\+\"\([0-9]\+\.\?\)\+\)/\1-pre.${{ github.run_number }}/" 'package.json'
-#       - run: npm publish --access public --tag next
-#         env:
-#           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
 #   release:
 #     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@openmrs/esm-ohri-app",
-  "version": "0.5.0",
+  "name": "openmrs-esm-ohri-form",
+  "version": "0.7.0",
   "description": "A custom microfrontend for OpenMRS HIV Reference Implementation (OHRI)",
-  "browser": "dist/openmrs-esm-ohri-app.js",
+  "browser": "dist/openmrs-esm-ohri-form.js",
   "main": "src/index.ts",
   "license": "MIT",
   "homepage": "https://github.com/UCSF-IGHS/openmrs-esm-ohri#readme",


### PR DESCRIPTION
Enable Publish to NPM, comment Digital ocean, update esm name

There will be 3 servers with OHRI instances:

Dev (ohri-dev.globalhealthapp.net)

Staging (ohri-staging.globalhealthapp.net)

Demo (ohri-demo.globalhealthapp.net)

Each of these should be automatically deployed to, by the specifications below:

dev - for a merge into dev branch

staging - for a merge into master branch

demo - a manual deployment from a known tag from master (This is the most stable server)

![Screen Shot 2021-06-16 at 02 57 48](https://user-images.githubusercontent.com/4475142/122141946-b0911080-ce4e-11eb-99ed-713bb2221918.png)
