### PR TITLE
Fix condition for CD pre-release

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -72,8 +72,8 @@ jobs:
 
     needs: build
     
-    if: ${{ github.ref == 'refs/heads/working' }} 
-
+    if: ${{ github.ref == 'refs/heads/working' || 'refs/heads/dev' || 'refs/heads/master' }}  
+     
     steps:
       - uses: actions/checkout@v2
       - name: Download Artifacts


### PR DESCRIPTION
This commit, fixes the issue that the deploy on Dev only occurs after per-release which depends on working ref.