### PR TITLE
OHRI-275 Form validation errors

### DIFF
--- a/src/forms/components/inputs/_input.scss
+++ b/src/forms/components/inputs/_input.scss
@@ -125,7 +125,6 @@
 
 .errorLegend legend, .errorLabel label {
   color: #da1e28;
-  font-size: 0.875rem !important;
 }
 
 .unspecified > div label {


### PR DESCRIPTION
This fixes the issue with the missing validation error for some questions.

- Adds validation colour.
- Removes fontSize.(Incase in font size when validation error is shown)

Related Ticket: [ohri-275](https://ohri.atlassian.net/browse/OHRI-275)