### PR TITLE
Include initial layout, empty state, tabs

### DIFF
--- a/src/covid/covid.scss
+++ b/src/covid/covid.scss
@@ -26,3 +26,6 @@
     margin: 0 $spacing-03;
   }
  
+  .tabContainer div[role='tabpanel'] {
+    padding: 0 !important;
+  }

--- a/src/covid/pages/lab-results.encounter-list.tsx
+++ b/src/covid/pages/lab-results.encounter-list.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from '../covid.scss';
+import { Tabs, Tab } from 'carbon-components-react';
+import EmptyState from '../../components/empty-state/empty-state.component';
 
 import {
   covidRapidTestResultDate_UUID,
@@ -92,17 +94,30 @@ const CovidLabResults: React.FC<CovidLabWidgetProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const headerTitle = t('covidLabResults', 'Lab Results');
   const displayText = t('covidLabResults', 'Lab Results');
+  const headerTitlePending = t('covidLabResults', 'Pending Lab Orders');
+  const displayTextPending = t('covidLabResults', 'Pending Lab Orders');
+
   return (
-    <EncounterList
-      patientUuid={patientUuid}
-      encounterUuid={covid_Assessment_EncounterUUID}
-      form={{ package: 'covid', name: 'covid_lab_test' }}
-      columns={columns}
-      description={displayText}
-      headerTitle={headerTitle}
-      dropdownText="Add"
-      hideFormLauncher
-    />
+    <div className={styles.tabContainer}>
+      <Tabs>
+        <Tab label="Lab results">
+          <EncounterList
+            patientUuid={patientUuid}
+            encounterUuid={covid_Assessment_EncounterUUID}
+            form={{ package: 'covid', name: 'covid_lab_test' }}
+            columns={columns}
+            description={displayText}
+            headerTitle={headerTitle}
+            dropdownText="Add"
+            hideFormLauncher
+          />
+        </Tab>
+
+        <Tab label="Pending Lab Orders">
+          <EmptyState displayText={displayTextPending} headerTitle={headerTitlePending} />
+        </Tab>
+      </Tabs>
+    </div>
   );
 };
 


### PR DESCRIPTION
This PR covers the below:

- [ ] Tab Layout
- [ ] Lab Results widget
- [ ] Pending Lab Result Empty State
- [ ] 
<img width="1053" alt="Screen Shot 2021-11-02 at 09 23 19" src="https://user-images.githubusercontent.com/4475142/139803944-6ec58069-33f4-46b0-89f5-2a5f72b1e2d2.png">

<img width="1044" alt="Screen Shot 2021-11-02 at 09 21 47" src="https://user-images.githubusercontent.com/4475142/139803934-a98e8748-fbf7-4233-95c8-c434392f236f.png">

