### PR TITLE
OHRI-404: Short names and synonyms for ALL lists

### DIFF
--- a/src/components/encounter-list/encounter-list.component.tsx
+++ b/src/components/encounter-list/encounter-list.component.tsx
@@ -55,7 +55,7 @@ export function getObsFromEncounter(encounter, obsConcept, isDate?: Boolean, isT
   }
 
   if (typeof obs.value === 'object') {
-    return obs.value.name.name;
+    return obs.value.names?.find(conceptName => conceptName.conceptNameType === 'SHORT')?.name || obs.value.name.name;
   }
   return obs.value;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,8 @@ export const basePath = '${openmrsSpaBase}/patient/';
 export const encounterRepresentation =
   'custom:(uuid,encounterDatetime,location:(uuid,name),' +
   'encounterProviders:(uuid,provider:(uuid,name)),' +
-  'obs:(uuid,obsDatetime,groupMembers,concept:(uuid,name:(uuid,name)),value:(uuid,name:(uuid,name))))';
+  'obs:(uuid,obsDatetime,groupMembers,concept:(uuid,name:(uuid,name)),value:(uuid,name:(uuid,name),' +
+  'names:(uuid,conceptNameType,name))))';
 
 // Final HIV Test Result Concepts
 export const finalHIVCodeConcept = 'e16b0068-b6a2-46b7-aba9-e3be00a7b4ab';


### PR DESCRIPTION
- OHRI-404: Short names and synonyms for ALL lists
- Added `names:(uuid,conceptNameType,name)` to retrieve `conceptNames` of coded value
- Encounter lists to first check for short name else default to the default `fully specified`