### PR TITLE
OHRI-622 Blank HIV status when patient is first added to pre-test list

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -157,7 +157,7 @@ export function fetchPatientsFinalHIVStatus(patientUUID: string) {
     if (data.entry?.length) {
       return data.entry[0].resource.valueCodeableConcept.coding[0].display;
     }
-    return 'Negative';
+    return '--';
   });
 }
 
@@ -178,7 +178,7 @@ export function fetchPatientComputedConcept_HIV_Status(patientUUID: string) {
     if (data.entry?.length) {
       return data.entry[0].resource.valueCodeableConcept.coding[0].display;
     }
-    return 'Negative';
+    return '--';
   });
 }
 


### PR DESCRIPTION
OHRI-622 Make HIV status blank when patient is first added to pre-test list