### PR TITLE
OHRI-650: Show correct test results

### DIFF
--- a/src/covid/pages/lab-results.encounter-list.tsx
+++ b/src/covid/pages/lab-results.encounter-list.tsx
@@ -24,6 +24,8 @@ export const covidEncounterRepresentation =
   'encounterProviders:(uuid,provider:(uuid,name)),' +
   'obs:(uuid,obsDatetime,concept:(uuid,name:(uuid,name)),value:(uuid,name:(uuid,name))))';
 
+const pcrTestResult = '3f4ee14b-b4ab-4597-9fe9-406883b63d76';
+const rapidTestResult = 'cbcbb029-f11f-4437-9d53-1d0f0a170433';
 interface CovidLabWidgetProps {
   patientUuid: string;
 }
@@ -72,7 +74,8 @@ const columnsLab: EncounterListColumn[] = [
     key: 'lastTestResult',
     header: 'Test Result',
     getValue: encounter => {
-      return getObsFromEncounter(encounter, covidTestResultConcept_UUID);
+      const pcrResult = getObsFromEncounter(encounter, pcrTestResult);
+      return pcrResult && pcrResult != '--' ? pcrResult : getObsFromEncounter(encounter, rapidTestResult);
     },
   },
   {

--- a/src/forms/ohri-form.component.tsx
+++ b/src/forms/ohri-form.component.tsx
@@ -105,7 +105,7 @@ const OHRIForm: React.FC<OHRIFormProps> = ({
       },
     };
     registerExtension(extDetails.id, extDetails);
-    attach('patient-chart-workspace-header-slot', extDetails.id);
+    // attach('patient-chart-workspace-header-slot', extDetails.id);
 
     return () => {
       detach('patient-chart-workspace-header-slot', extDetails.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,13 @@ function setupOpenMRS() {
           columnSpan: 4,
         },
       },
+      {
+        name: 'form-render-link',
+        slot: 'app-menu-slot',
+        load: getAsyncLifecycle(() => import('./links/form-render-app-menu-link.component'), options),
+        online: true,
+        offline: true,
+      },
     ],
   };
 }

--- a/src/links/form-render-app-menu-link.component.tsx
+++ b/src/links/form-render-app-menu-link.component.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ConfigurableLink } from '@openmrs/esm-framework';
+
+export default function FormRenderAppMenuLink() {
+  const { t } = useTranslation();
+  return (
+    <ConfigurableLink to="${openmrsSpaBase}/form-render-test">
+      {t('formRenderMenuLink', 'Form render')}
+    </ConfigurableLink>
+  );
+}


### PR DESCRIPTION
This commit covers the following:

- Fixes covid lab result column in the lab results widget
- Adds form render test link to menu items
- Temporarily unmount toggle from form's header that is breaking the extension system