### PR TITLE
OHRI-781 ART Therapy form not saving

### DIFF
--- a/src/packages/hiv/forms/care-and-treatment/art-therapy/1.0.json
+++ b/src/packages/hiv/forms/care-and-treatment/art-therapy/1.0.json
@@ -2545,16 +2545,6 @@
                   }
                 ]
               },
-              "behaviours": [
-                {
-                  "intent": "*",
-                  "required": "false",
-                  "unspecified": "true",
-                  "hide": {
-                    "hideWhenExpression": "false"
-                  }
-                }
-              ],
               "id": "addNotes"
             }
           ]


### PR DESCRIPTION
Removed validations on Notes field so that form can save even without notes.