### PR TITLE
Add support for lazy cell values in Encounter lists

### DIFF
--- a/packages/esm-commons-lib/src/components/data-table/o-table.component.tsx
+++ b/packages/esm-commons-lib/src/components/data-table/o-table.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   DataTable,
   Table,
@@ -10,6 +10,7 @@ import {
   TableRow,
 } from '@carbon/react';
 import styles from './o-table.scss';
+import { LazyCell } from '../lazy-cell/lazy-cell.component';
 
 interface TableProps {
   tableHeaders: any;
@@ -40,7 +41,9 @@ export const OTable: React.FC<TableProps> = ({ tableHeaders, tableRows }) => {
               {rows.map((row) => (
                 <TableRow key={row.id}>
                   {row.cells.map((cell) => (
-                    <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
+                    <TableCell key={cell.id}>
+                      <LazyCell lazyValue={cell.value?.content ?? cell.value} />
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}

--- a/packages/esm-commons-lib/src/components/encounter-tile/encounter-tile.component.tsx
+++ b/packages/esm-commons-lib/src/components/encounter-tile/encounter-tile.component.tsx
@@ -3,13 +3,14 @@ import { CodeSnippetSkeleton, Tile, Column } from '@carbon/react';
 import React, { useEffect, useState } from 'react';
 import styles from './encounter-tile.scss';
 import { encounterRepresentation } from '../../constants';
+import { LazyCell } from '../lazy-cell/lazy-cell.component';
 
 export interface EncounterTileColumn {
   key: string;
   header: string;
   encounterUuid: string;
-  getObsValue: (encounter: any) => string;
-  getSummaryObsValue?: (encounter: any) => string;
+  getObsValue: (encounter: any) => string | Promise<string>;
+  getSummaryObsValue?: (encounter: any) => string | Promise<string>;
   encounter?: any;
   hasSummary?: Boolean;
 }
@@ -61,9 +62,13 @@ export const EncounterTile: React.FC<EncounterTileProps> = ({ patientUuid, colum
               <div className={styles.tileBox}>
                 <div className={styles.tileBoxColumn}>
                   <span className={styles.tileTitle}> {column.header} </span>
-                  <span className={styles.tileValue}>{column.getObsValue(column.encounter)}</span>
+                  <span className={styles.tileValue}>
+                    <LazyCell lazyValue={column.getObsValue(column.encounter)} />
+                  </span>
                   {column.hasSummary ? (
-                    <span className={styles.tileTitle}> {column.getSummaryObsValue(column.encounter)} </span>
+                    <span className={styles.tileTitle}>
+                      <LazyCell lazyValue={column.getSummaryObsValue(column.encounter)} />
+                    </span>
                   ) : (
                     <span></span>
                   )}

--- a/packages/esm-commons-lib/src/components/lazy-cell/lazy-cell.component.tsx
+++ b/packages/esm-commons-lib/src/components/lazy-cell/lazy-cell.component.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect, useState } from 'react';
+
+export function LazyCell({ lazyValue }) {
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    Promise.resolve(lazyValue).then((value) => setValue(value));
+  }, [lazyValue]);
+
+  return <>{value}</>;
+}


### PR DESCRIPTION
Example usage:

```js
    },
    {
        key: 'outcome',
        header: t('outcome', 'Outcome'),
        getValue: (encounter) => {
          const valueY = await fetchLazyValue();
          return getDisplayFromEncounterBasedOnValueY(encounter, valueY)
        },
     },
```