### PR TITLE
'swr' npm-package should only be defined as a devDependency

### DIFF
--- a/packages/esm-cervical-cancer-app/package.json
+++ b/packages/esm-cervical-cancer-app/package.json
@@ -41,8 +41,7 @@
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",
-    "react-i18next": "^11.18.6",
-    "swr": "^1.1.2"
+    "react-i18next": "^11.18.6"
   },
   "devDependencies": {
     "webpack": "^5.74.0"

--- a/packages/esm-hiv-app/package.json
+++ b/packages/esm-hiv-app/package.json
@@ -44,7 +44,6 @@
     "dayjs": "^1.8.16",
     "react": "^18.2.0",
     "react-i18next": "^11.7.0",
-    "swr": "^1.1.2",
     "webpack": "^5.74.0"
   },
   "devDependencies": {

--- a/packages/esm-ohri-pmtct-app/package.json
+++ b/packages/esm-ohri-pmtct-app/package.json
@@ -41,8 +41,7 @@
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",
-    "react-i18next": "^11.18.6",
-    "swr": "^1.1.2"
+    "react-i18next": "^11.18.6"
   },
   "devDependencies": {
     "webpack": "^5.74.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,7 +3506,6 @@ __metadata:
     dayjs: ^1.8.16
     react: ^18.2.0
     react-i18next: ^11.18.6
-    swr: ^1.1.2
   languageName: unknown
   linkType: soft
 
@@ -3611,7 +3610,6 @@ __metadata:
     dayjs: ^1.8.16
     react: ^18.2.0
     react-i18next: ^11.7.0
-    swr: ^1.1.2
     webpack: ^5.74.0
   languageName: unknown
   linkType: soft
@@ -3628,7 +3626,6 @@ __metadata:
     dayjs: ^1.8.16
     react: ^18.2.0
     react-i18next: ^11.18.6
-    swr: ^1.1.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The 'swr' entrie(s) under peer dependencies causes conflicts of the installed package by yarn with what is required by the forms engine. 