### PR TITLE
OHRI-1408 "post-test counselling" removed from HTS menu options

### DIFF
--- a/packages/esm-commons-lib/src/hooks/usePatientList.tsx
+++ b/packages/esm-commons-lib/src/hooks/usePatientList.tsx
@@ -29,7 +29,7 @@ export function usePatientList(offSet: number = 0, pageSize: number = 15) {
 
       const patientActions = (
         <OverflowMenu flipped>
-          <AddPatientToListOverflowMenuItem patientUuid={patient.resource.id} excludeCohorts={[]} />
+          <AddPatientToListOverflowMenuItem patientUuid={patient.resource.id} excludeCohorts={['Post-Test Counselling']} />
         </OverflowMenu>
       );
 

--- a/packages/esm-hiv-app/src/views/hts/home/patient-tabs/ohri-patient-tabs.component.tsx
+++ b/packages/esm-hiv-app/src/views/hts/home/patient-tabs/ohri-patient-tabs.component.tsx
@@ -49,7 +49,7 @@ function OHRIPatientTabs() {
             cohortSlotName="waiting-for-hiv-testing-slot"
             addPatientToListOptions={{
               isEnabled: true,
-              excludeCohorts: [],
+              excludeCohorts: ['Post-Test Counselling'],
             }}
             launchableForm={{
               package: formPackage,


### PR DESCRIPTION
Ohri 1408: "post-test counselling" removed from HTS menu options