### PR TITLE
Ohri 1419: Changing programs to Programmes.

### DIFF
--- a/packages/esm-ohri-core-app/src/ohri-dashboard/side-menu/ohri-dashboard-side-nav.component.tsx
+++ b/packages/esm-ohri-core-app/src/ohri-dashboard/side-menu/ohri-dashboard-side-nav.component.tsx
@@ -11,7 +11,7 @@ const OHRIDashboardSideNav = () => {
       <SideNavItems>
         <ExtensionSlot name="dashboard-links-slot" />
 
-        <p className={styles.sideNavTextHeader}>{t('programs', 'Programs')}</p>
+        <p className={styles.sideNavTextHeader}>{t('programmes', 'Programmes')}</p>
 
         <ExtensionSlot name="dashboard-slot" />
       </SideNavItems>

--- a/packages/esm-ohri-core-app/translations/en.json
+++ b/packages/esm-ohri-core-app/translations/en.json
@@ -1,3 +1,4 @@
 {
-  "programs": "Programs"
+  "programs": "Programs",
+  "programmes": "Programmes"
 }


### PR DESCRIPTION
- "Programs" on ohri-dashboard-side-nav.component changed to "Programmes"
- Added "programmes" : "Programmes" to the ohri-core translation file.

<img width="1440" alt="Screenshot 2023-06-13 at 19 22 18" src="https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/51090527/cc68434d-caad-4cb1-be97-960da91cc959">
