### PR TITLE
Refactoring PMTCT encounterlists to use form names for forms loaded from the backend

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/views/child-health/tabs/infant-postnatal-care.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/child-health/tabs/infant-postnatal-care.component.tsx
@@ -121,7 +121,7 @@ const InfantPostnatalList: React.FC<InfantPostnatalListProps> = ({ patientUuid }
       patientUuid={patientUuid}
       encounterType={infantPostnatalEncounterType}
       // TODO: replace with form name as configured in the backend.
-      formList={[{ name: 'infant_postnatal' }]}
+      formList={[{ name: 'Infant - Postanal Form' }]}
       columns={columns}
       description={headerTitle}
       headerTitle={headerTitle}

--- a/packages/esm-ohri-pmtct-app/src/views/maternal-health/tabs/antenatal-care.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/maternal-health/tabs/antenatal-care.component.tsx
@@ -119,7 +119,7 @@ const AntenatalCareList: React.FC<AntenatalCareListProps> = ({ patientUuid }) =>
       patientUuid={patientUuid}
       encounterType={antenatalEncounterType}
       // TODO: replace with form name as configured in the backend.
-      formList={[{ name: 'antenatal' }]}
+      formList={[{ name: 'Antenatal Form' }]}
       columns={columns}
       description={headerTitle}
       headerTitle={headerTitle}

--- a/packages/esm-ohri-pmtct-app/src/views/maternal-health/tabs/labour-delivery.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/maternal-health/tabs/labour-delivery.component.tsx
@@ -93,7 +93,7 @@ const LabourDeliveryList: React.FC<LabourDeliveryListProps> = ({ patientUuid }) 
       patientUuid={patientUuid}
       encounterType={labourAndDeliveryEncounterType}
       // TODO: replace with form name as configured in the backend.
-      formList={[{ name: 'labour_and_delivery' }]}
+      formList={[{ name: 'Labour & Delivery Form' }]}
       columns={columns}
       description={headerTitle}
       headerTitle={headerTitle}

--- a/packages/esm-ohri-pmtct-app/src/views/maternal-health/tabs/postnatal-care.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/maternal-health/tabs/postnatal-care.component.tsx
@@ -99,7 +99,7 @@ const PostnatalCareList: React.FC<PostnatalCareListProps> = ({ patientUuid }) =>
       patientUuid={patientUuid}
       encounterType={motherPostnatalEncounterType}
       // TODO: replace with form name as configured in the backend.
-      formList={[{ name: 'mother_postnatal_form' }]}
+      formList={[{ name: 'Mother - Postnatal Form' }]}
       columns={columns}
       description={headerTitle}
       headerTitle={headerTitle}


### PR DESCRIPTION
Refactoring PMTCT encounterlists to use form names for forms loaded from the backend