### PR TITLE
Updated- HIV Care & Treatment and HIV Prevention Forms name

### DIFF
--- a/packages/esm-hiv-app/src/views/general-counselling/tabs/disclosure.component.tsx
+++ b/packages/esm-hiv-app/src/views/general-counselling/tabs/disclosure.component.tsx
@@ -33,14 +33,14 @@ const DisclosureList: React.FC<DisclosureListProps> = ({ patientUuid }) => {
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'peads_disclosure', package: 'hiv' },
+              form: { name: 'Age Appropriate Disclosure Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'View Details',
               mode: 'view',
             },
             {
-              form: { name: 'peads_disclosure', package: 'hiv' },
+              form: { name: 'Age Appropriate Disclosure Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'Edit Form',

--- a/packages/esm-hiv-app/src/views/general-counselling/tabs/intimate-partner-violence.component.tsx
+++ b/packages/esm-hiv-app/src/views/general-counselling/tabs/intimate-partner-violence.component.tsx
@@ -52,14 +52,14 @@ const IntimatePartnerViolenceList: React.FC<IntimatePartnerViolenceListProps> = 
         header: t('actions', 'Actions'),
         getValue: (encounter) => [
           {
-            form: { name: 'intimate_partner', package: 'hiv' },
+            form: { name: 'Intimate Partner Violence Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: 'View Details',
             mode: 'view',
           },
           {
-            form: { name: 'intimate_partner', package: 'hiv' },
+            form: { name: 'Intimate Partner Violence Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: 'Edit Form',

--- a/packages/esm-hiv-app/src/views/general-counselling/tabs/mental-health-assessment.component.tsx
+++ b/packages/esm-hiv-app/src/views/general-counselling/tabs/mental-health-assessment.component.tsx
@@ -60,14 +60,14 @@ const MentalHealthAssessmentList: React.FC<MentalHealthAssessmentListProps> = ({
         header: t('actions', 'Actions'),
         getValue: (encounter) => [
           {
-            form: { name: 'mental_health_assessment', package: 'hiv' },
+            form: { name: 'Mental Health Assessment Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: 'View Details',
             mode: 'view',
           },
           {
-            form: { name: 'mental_health_assessment', package: 'hiv' },
+            form: { name: 'Mental Health Assessment Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: 'Edit Form',

--- a/packages/esm-hiv-app/src/views/hiv-testing-services/tab-list/hts-overview-list.component.tsx
+++ b/packages/esm-hiv-app/src/views/hiv-testing-services/tab-list/hts-overview-list.component.tsx
@@ -57,14 +57,14 @@ const HtsOverviewList: React.FC<HtsOverviewListProps> = ({ patientUuid }) => {
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { package: 'hiv', name: 'hts' },
+              form: { package: 'hiv', name: 'HIV Testing' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { package: 'hiv', name: 'hts' },
+              form: { package: 'hiv', name: 'HIV Testing' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/hiv-testing-services/tab-list/pre-test.component.tsx
+++ b/packages/esm-hiv-app/src/views/hiv-testing-services/tab-list/pre-test.component.tsx
@@ -62,14 +62,14 @@ const HIVPreTestTabList: React.FC<HIVPreTestTabListProps> = ({ patientUuid }) =>
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'hts_who', package: 'hiv' },
+              form: { name: 'HTS Pre-Test Counselling', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { name: 'hts_who', package: 'hiv' },
+              form: { name: 'HTS Pre-Test Counselling', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/partner-notification-services/partner-notification.component.tsx
+++ b/packages/esm-hiv-app/src/views/partner-notification-services/partner-notification.component.tsx
@@ -70,14 +70,14 @@ const PartnerNotificationList: React.FC<PartnerNotificationListProps> = ({ patie
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'patner_notification', package: 'hiv' },
+              form: { name: 'Partner Notification Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'View Details',
               mode: 'view',
             },
             {
-              form: { name: 'patner_notification', package: 'hiv' },
+              form: { name: 'Partner Notification Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'Edit Form',

--- a/packages/esm-hiv-app/src/views/partner-notification-services/tabs/contact-tracing.component.tsx
+++ b/packages/esm-hiv-app/src/views/partner-notification-services/tabs/contact-tracing.component.tsx
@@ -46,14 +46,14 @@ const ContactTracingList: React.FC<ContactTracingListProps> = ({ patientUuid }) 
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'contact_tracing', package: 'hiv' },
+              form: { name: 'Contact Tracing Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'View Details',
               mode: 'view',
             },
             {
-              form: { name: 'contact_tracing', package: 'hiv' },
+              form: { name: 'Contact Tracing Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'Edit Form',

--- a/packages/esm-hiv-app/src/views/partner-notification-services/tabs/patient-tracing.component.tsx
+++ b/packages/esm-hiv-app/src/views/partner-notification-services/tabs/patient-tracing.component.tsx
@@ -46,14 +46,14 @@ const PatientTracingList: React.FC<PatientTracingListProps> = ({ patientUuid }) 
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'patient_tracing', package: 'hiv' },
+              form: { name: 'Patient Tracing Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'View Details',
               mode: 'view',
             },
             {
-              form: { name: 'patient_tracing', package: 'hiv' },
+              form: { name: 'Patient Tracing Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: 'Edit Form',

--- a/packages/esm-hiv-app/src/views/program-management/tabs/art-therapy-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/program-management/tabs/art-therapy-tab.component.tsx
@@ -175,14 +175,14 @@ const ArtTherapyTabList: React.FC<ArtTherapyTabListProps> = ({ patientUuid }) =>
         header: t('actions', 'Actions'),
         getValue: (encounter) => [
           {
-            form: { name: 'art_therapy', package: 'hiv' },
+            form: { name: 'ART Therapy Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('viewDetails', 'View Details'),
             mode: 'view',
           },
           {
-            form: { name: 'art_therapy', package: 'hiv' },
+            form: { name: 'ART Therapy Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/program-management/tabs/death-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/program-management/tabs/death-tab.component.tsx
@@ -45,14 +45,14 @@ const DeathTabList: React.FC<DeathTabListProps> = ({ patientUuid }) => {
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'death_form', package: 'hiv' },
+              form: { name: 'Death Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { name: 'death_form', package: 'hiv' },
+              form: { name: 'Death Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/program-management/tabs/hiv-enrolment-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/program-management/tabs/hiv-enrolment-tab.component.tsx
@@ -77,14 +77,14 @@ const HIVEnrolmentTabList: React.FC<HIVEnrolmentTabListProps> = ({ patientUuid }
         header: t('actions', 'Actions'),
         getValue: (encounter) => [
           {
-            form: { name: 'service_enrolment', package: 'hiv' },
+            form: { name: 'Service Enrolment Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('viewDetails', 'View Details'),
             mode: 'view',
           },
           {
-            form: { name: 'service_enrolment', package: 'hiv' },
+            form: { name: 'Service Enrolment Form', package: 'hiv' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/program-management/tabs/service-delivery-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/program-management/tabs/service-delivery-tab.component.tsx
@@ -46,14 +46,14 @@ const ServiceDeliveryTabList: React.FC<ServiceDeliveryTabListProps> = ({ patient
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'service_delivery', package: 'hiv' },
+              form: { name: 'Service Delivery Model Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { name: 'service_delivery', package: 'hiv' },
+              form: { name: 'Service Delivery Model Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/program-management/tabs/transfer-out-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/program-management/tabs/transfer-out-tab.component.tsx
@@ -62,14 +62,14 @@ const TransferOutTabList: React.FC<TransferOutTabListProps> = ({ patientUuid }) 
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'transfer_out', package: 'hiv' },
+              form: { name: 'Transfer Out Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { name: 'transfer_out', package: 'hiv' },
+              form: { name: 'Transfer Out Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/visits/tabs/clinical-visit-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/visits/tabs/clinical-visit-tab.component.tsx
@@ -69,14 +69,14 @@ const ClinicalVisitList: React.FC<ClinicalVisitListProps> = ({ patientUuid }) =>
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'clinical_visit', package: 'hiv' },
+              form: { name: 'POC Clinical Visit Form v2', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { name: 'clinical_visit', package: 'hiv' },
+              form: { name: 'POC Clinical Visit Form v2', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),

--- a/packages/esm-hiv-app/src/views/visits/tabs/express-visit-tab.component.tsx
+++ b/packages/esm-hiv-app/src/views/visits/tabs/express-visit-tab.component.tsx
@@ -59,14 +59,14 @@ const ExpressVisitList: React.FC<ExpressVisitListProps> = ({ patientUuid }) => {
         getValue: (encounter) => {
           const baseActions = [
             {
-              form: { name: 'express_visit', package: 'hiv' },
+              form: { name: 'POC Express Visit Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('viewDetails', 'View Details'),
               mode: 'view',
             },
             {
-              form: { name: 'express_visit', package: 'hiv' },
+              form: { name: 'POC Express Visit Form', package: 'hiv' },
               encounterUuid: encounter.uuid,
               intent: '*',
               label: t('editForm', 'Edit Form'),


### PR DESCRIPTION
Updated the forms in HIV Care & Treatment and HIV Prevention Forms-> Change of Form name, to solve the following issues;
1. Unable to form 
2. unable to view/edit form