### PR TITLE
OHRI-1547: Action buttons for Visit section must work on the MNCH summary

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/views/mch-summary/tabs/hiv-exposed-infant.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/mch-summary/tabs/hiv-exposed-infant.component.tsx
@@ -223,7 +223,7 @@ const HivExposedInfant: React.FC<{
         header: t('actions', 'Actions'),
         getValue: (encounter) => [
           {
-            form: { name: 'infant_postnatal', package: 'child_health' },
+            form: { name: 'Infant - Postanal Form', package: 'child_health' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('viewDetails', 'View details'),


### PR DESCRIPTION
Action buttons for Visit section NOW work on the MNCH summary
![image](https://github.com/lucyjemutai/openmrs-esm-ohri/assets/130601439/9d4a45bb-9ae6-41bb-9fdc-d5ccfe9f84b9)

![image](https://github.com/lucyjemutai/openmrs-esm-ohri/assets/130601439/2a7cee91-b897-4775-8dc4-e6d5d688b915)