### PR TITLE
OHRI-1571 (Breaking) Upgrade app shell to v5

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ const config = {
     'react-i18next': '<rootDir>/__mocks__/react-i18next.js',
     'lodash-es': 'lodash',
     'react-markdown': '<rootDir>/__mocks__/react-markdown.tsx',
+    '^dexie$': require.resolve('dexie'),
   },
 };
 

--- a/jest.config.json
+++ b/jest.config.json
@@ -35,4 +35,3 @@
       "url": "http://localhost/"
     }
   }
-  

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.0.10",
+  "version": "1.1.0",
   "command": {
     "publish": {
       "verifyAccess": false,

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "scripts": {
     "start": "openmrs develop --backend https://ohri-dev.globalhealthapp.net --sources 'packages/esm-*-app/'",
     "start:core": "openmrs develop --backend https://ohri-dev.globalhealthapp.net --sources packages/esm-ohri-core-app",
+    "start:v5": "openmrs develop --backend https://dev3.openmrs.org --sources packages/esm-ohri-core-app",
     "start:covid": "openmrs develop --backend https://ohri-dev.globalhealthapp.net --sources packages/esm-covid-app",
     "start:hiv": "openmrs develop --backend https://ohri-dev.globalhealthapp.net --sources packages/esm-hiv-app",
     "start:cervical-cancer": "openmrs develop --backend https://ohri-dev.globalhealthapp.net --sources packages/esm-cervical-cancer-app",
     "start:pmtct": "openmrs develop --backend https://ohri-namibia-dev.globalhealthapp.net --sources 'packages/esm-ohri-pmtct-app/'",
     "start:form-render": "openmrs develop --backend https://ohri-demo.globalhealthapp.net --sources packages/esm-form-render-app",
-    "start:namibia": "openmrs develop --backend https://ohri-namibia-dev.globalhealthapp.net --sources 'packages/esm-*-app/'",
     "prettier": "prettier --fix --config prettier.config.js --write \"packages/**/*.{ts,tsx}\"",
     "prepare": "husky install",
     "test": "jest --config jest.config.json --verbose false --passWithNoTests",
@@ -34,8 +34,7 @@
     "extract-translations": "lerna run extract-translations -- --config ../../tools/i18next-parser.config.js",
     "ci:publish-next": "lerna publish from-package --no-git-reset --dist-tag next --yes",
     "ci:publish-next-patch": "lerna version patch && lerna publish from-package --no-git-reset --dist-tag next --yes",
-    "release": "lerna version --no-git-tag-version",
-    "ci:bump-form-engine-lib": "yarn up @openmrs/openmrs-form-engine-lib@next"
+    "release": "lerna version --no-git-tag-version"
   },
   "devDependencies": {
     "@openmrs/esm-framework": "next",

--- a/packages/esm-cervical-cancer-app/package.json
+++ b/packages/esm-cervical-cancer-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohri/openmrs-esm-ohri-cervical-cancer-app",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Cervical cancer microfrontend for OpenMRS HIV Reference Implementation (OHRI)",
   "browser": "dist/openmrs-esm-ohri-cervical-cancer-app.js",
   "main": "src/index.ts",
@@ -37,7 +37,7 @@
     "@carbon/react": "^1.13.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",

--- a/packages/esm-cervical-cancer-app/src/routes.json
+++ b/packages/esm-cervical-cancer-app/src/routes.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "backendDependencies": {
+    "webservices.rest": "^2.24.0"
+  },
+  "pages": [
+  ],
+  "extensions": [
+  ]
+}

--- a/packages/esm-commons-lib/package.json
+++ b/packages/esm-commons-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohri/openmrs-esm-ohri-commons-lib",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Commons library microfrontend of shared assets for OpenMRS HIV Reference Implementation (OHRI)",
   "browser": "dist/ohri-commons-lib.js",
   "main": "src/index.ts",
@@ -40,7 +40,7 @@
     "yup": "^0.29.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",

--- a/packages/esm-commons-lib/src/components/ohri-home/ohri-home-component.tsx
+++ b/packages/esm-commons-lib/src/components/ohri-home/ohri-home-component.tsx
@@ -38,21 +38,15 @@ export function OHRIHome(HomeProps) {
       <FlexGrid className={styles.mainWrapper}>
         <div className={styles.sectionContainer}>
           <ExtensionSlot
-            extensionSlotName={getSlotName(HomeProps.programme, OHRIHomeHeaderSlot)}
+            name={getSlotName(HomeProps.programme, OHRIHomeHeaderSlot)}
             state={{ title: HomeProps.dashboardTitle }}
           />
         </div>
         <div className={styles.sectionContainer}>
-          <ExtensionSlot
-            extensionSlotName={getSlotName(HomeProps.programme, OHRIHomeTileSlot)}
-            state={{ launchWorkSpace }}
-          />
+          <ExtensionSlot name={getSlotName(HomeProps.programme, OHRIHomeTileSlot)} state={{ launchWorkSpace }} />
         </div>
         <div className={styles.ohriHomeTabsContainer}>
-          <ExtensionSlot
-            extensionSlotName={getSlotName(HomeProps.programme, OHRIHomeTabSlot)}
-            state={{ launchWorkSpace }}
-          />
+          <ExtensionSlot name={getSlotName(HomeProps.programme, OHRIHomeTabSlot)} state={{ launchWorkSpace }} />
         </div>
       </FlexGrid>
     </>

--- a/packages/esm-commons-lib/src/components/patient-banner/patient-banner.component.tsx
+++ b/packages/esm-commons-lib/src/components/patient-banner/patient-banner.component.tsx
@@ -9,7 +9,7 @@ export const PatientBanner: React.FC<{ patient: any; hideActionsOverflow?: any }
   return (
     <div className={styles.patientBannerContainer}>
       <ExtensionSlot
-        extensionSlotName="patient-header-slot"
+        name="patient-header-slot"
         state={{
           patient,
           patientUuid: patient.id,

--- a/packages/esm-commons-lib/src/components/patient-list-cohort/patient-list-cohort.component.tsx
+++ b/packages/esm-commons-lib/src/components/patient-list-cohort/patient-list-cohort.component.tsx
@@ -328,7 +328,7 @@ export const CohortPatientList: React.FC<CohortPatientListProps> = ({
           message={t('noPatientSidenav', 'There are no patients in this list.')}
         />
       ) : (
-        <ExtensionSlot extensionSlotName={cohortSlotName} state={state} key={counter} />
+        <ExtensionSlot name={cohortSlotName} state={state} key={counter} />
       )}
     </div>
   );

--- a/packages/esm-commons-lib/src/utils/createOHRIDashboardLink.tsx
+++ b/packages/esm-commons-lib/src/utils/createOHRIDashboardLink.tsx
@@ -23,7 +23,7 @@ export const createOHRIDashboardLink = (meta) => {
     if (meta.isFolder) {
       return (
         <SideNavMenu renderIcon={meta.config.icon} title={meta.title}>
-          <ExtensionSlot extensionSlotName={meta.slot} />
+          <ExtensionSlot name={meta.slot} />
         </SideNavMenu>
       );
     } else if (meta.isLink) {

--- a/packages/esm-covid-app/package.json
+++ b/packages/esm-covid-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohri/openmrs-esm-ohri-covid-app",
-  "version": "1.0.9-alpha.0",
+  "version": "1.1.0",
   "description": "COVID Microfrontend for OpenMRS HIV Reference Implementation (OHRI)",
   "browser": "dist/openmrs-esm-ohri-covid-app.js",
   "main": "src/index.ts",
@@ -39,7 +39,7 @@
     "moment": "^2.29.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",

--- a/packages/esm-covid-app/src/routes.json
+++ b/packages/esm-covid-app/src/routes.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "backendDependencies": {
+    "webservices.rest": "^2.24.0"
+  },
+  "pages": [
+  ],
+  "extensions": [
+  ]
+}

--- a/packages/esm-covid-app/src/views/dashboard/summary-tiles/outcome-list-tile.component.tsx
+++ b/packages/esm-covid-app/src/views/dashboard/summary-tiles/outcome-list-tile.component.tsx
@@ -150,7 +150,7 @@ export const Outcomes: React.FC<{}> = () => {
       {!isLoading && !patients.length ? (
         <TableEmptyState tableHeaders={columns} message={t('noPatientList', 'There are no patients in this list.')} />
       ) : (
-        <ExtensionSlot extensionSlotName="outcomes-table-slot" state={state} key={counter} />
+        <ExtensionSlot name="outcomes-table-slot" state={state} key={counter} />
       )}
     </div>
   );

--- a/packages/esm-covid-app/src/views/dashboard/summary-tiles/vaccination-tile-list.component.tsx
+++ b/packages/esm-covid-app/src/views/dashboard/summary-tiles/vaccination-tile-list.component.tsx
@@ -141,7 +141,7 @@ export const Vaccinations: React.FC<{}> = () => {
       {!isLoading && !patients.length ? (
         <TableEmptyState tableHeaders={columns} message={t('noPatientList', 'There are no patients in this list.')} />
       ) : (
-        <ExtensionSlot extensionSlotName="covid-vaccination-table-slot" state={state} key={counter} />
+        <ExtensionSlot name="covid-vaccination-table-slot" state={state} key={counter} />
       )}
     </div>
   );

--- a/packages/esm-form-render-app/package.json
+++ b/packages/esm-form-render-app/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@carbon/react": "1.x",
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/openmrs-form-engine-lib": "1.x",
     "react": "^18.2.0",
     "react-i18next": "^11.18.6"

--- a/packages/esm-form-render-app/src/index.ts
+++ b/packages/esm-form-render-app/src/index.ts
@@ -1,36 +1,19 @@
 import { defineConfigSchema, getAsyncLifecycle } from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
-import { backendDependencies } from './openmrs-backend-dependencies';
 
-const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
+export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
-function setupOpenMRS() {
-  const moduleName = '@ohri/openmrs-esm-ohri-form-render-app';
+const moduleName = '@ohri/openmrs-esm-ohri-form-render-app';
 
-  const options = {
-    featureName: 'ohri-form-render',
-    moduleName,
-  };
+const options = {
+  featureName: 'ohri-form-render',
+  moduleName,
+};
 
+export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
-
-  return {
-    pages: [
-      {
-        load: getAsyncLifecycle(() => import('./root'), options),
-        route: /^form-render-test/,
-      },
-    ],
-    extensions: [
-      {
-        name: 'form-render-link',
-        slot: 'app-menu-slot',
-        load: getAsyncLifecycle(() => import('./form-render-app-menu-link.component'), options),
-        online: true,
-        offline: true,
-      },
-    ],
-  };
 }
 
-export { backendDependencies, importTranslation, setupOpenMRS };
+export const FormRenderTest = getAsyncLifecycle(() => import('./root'), options);
+
+export const FormRenderLink = getAsyncLifecycle(() => import('./form-render-app-menu-link.component'), options);

--- a/packages/esm-form-render-app/src/routes.json
+++ b/packages/esm-form-render-app/src/routes.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "backendDependencies": {
+    "webservices.rest": "^2.24.0"
+  },
+  "pages": [
+    {
+      "component": "FormRenderTest",
+      "route": "form-render-test"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "form-render-link",
+      "slot": "app-menu-slot",
+      "component": "FormRenderLink"
+    }
+  ]
+}

--- a/packages/esm-hiv-app/package.json
+++ b/packages/esm-hiv-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohri/openmrs-esm-ohri-hiv-app",
-  "version": "1.0.9-alpha.0",
+  "version": "1.1.0",
   "description": "HIV microfrontend for OpenMRS HIV Reference Implementation (OHRI)",
   "browser": "dist/openmrs-esm-ohri-hiv-app.js",
   "main": "src/index.ts",
@@ -39,7 +39,7 @@
     "moment": "^2.29.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",

--- a/packages/esm-hiv-app/src/routes.json
+++ b/packages/esm-hiv-app/src/routes.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "backendDependencies": {
+    "webservices.rest": "^2.24.0"
+  },
+  "pages": [
+    {
+      "component": "root",
+      "route": "login",
+      "online": true,
+      "offline": true
+    }
+  ]
+}

--- a/packages/esm-hiv-app/src/routes.json
+++ b/packages/esm-hiv-app/src/routes.json
@@ -4,11 +4,7 @@
     "webservices.rest": "^2.24.0"
   },
   "pages": [
-    {
-      "component": "root",
-      "route": "login",
-      "online": true,
-      "offline": true
-    }
+  ],
+  "extensions": [
   ]
 }

--- a/packages/esm-hiv-app/src/views/hts/home/summary-tiles/linked-to-care-in-last-14-days-list-tile.component.tsx
+++ b/packages/esm-hiv-app/src/views/hts/home/summary-tiles/linked-to-care-in-last-14-days-list-tile.component.tsx
@@ -151,7 +151,7 @@ export const LinkedToCareInLast14Days: React.FC<{}> = () => {
       {!isLoading && !patients.length ? (
         <TableEmptyState tableHeaders={columns} message="There are no patients in this list." />
       ) : (
-        <ExtensionSlot extensionSlotName="linked-to-care-last-14-days-table-slot" state={state} key={counter} />
+        <ExtensionSlot name="linked-to-care-last-14-days-table-slot" state={state} key={counter} />
       )}
     </div>
   );

--- a/packages/esm-hiv-app/src/views/hts/home/summary-tiles/positive-in-last-14-days-list-tile.component.tsx
+++ b/packages/esm-hiv-app/src/views/hts/home/summary-tiles/positive-in-last-14-days-list-tile.component.tsx
@@ -151,7 +151,7 @@ export const PositiveInLast14Days: React.FC<{}> = () => {
       {!isLoading && !patients.length ? (
         <TableEmptyState tableHeaders={columns} message="There are no patients in this list." />
       ) : (
-        <ExtensionSlot extensionSlotName="positive-in-last-14-days-table-slot" state={state} key={counter} />
+        <ExtensionSlot name="positive-in-last-14-days-table-slot" state={state} key={counter} />
       )}
     </div>
   );

--- a/packages/esm-hiv-app/src/views/hts/home/summary-tiles/today-client-list-tile.component.tsx
+++ b/packages/esm-hiv-app/src/views/hts/home/summary-tiles/today-client-list-tile.component.tsx
@@ -151,7 +151,7 @@ export const TodaysClientList: React.FC<{}> = () => {
       {!isLoading && !patients.length ? (
         <TableEmptyState tableHeaders={columns} message="There are no patients in this list." />
       ) : (
-        <ExtensionSlot extensionSlotName="today-clients-table-slot" state={state} key={counter} />
+        <ExtensionSlot name="today-clients-table-slot" state={state} key={counter} />
       )}
     </div>
   );

--- a/packages/esm-hiv-app/src/views/lab-results/overview/lab-results-overview.component.tsx
+++ b/packages/esm-hiv-app/src/views/lab-results/overview/lab-results-overview.component.tsx
@@ -41,10 +41,7 @@ const LabResultsOverview: React.FC<OverviewListProps> = ({ patientUuid }) => {
           </TabPanel>
           <TabPanel>
             <div className={styles.padding}>
-              <ExtensionSlot
-                extensionSlotName="ohri-lab-test-result-filtered-overview-slot"
-                state={{ patientUuid, filter }}
-              />
+              <ExtensionSlot name="ohri-lab-test-result-filtered-overview-slot" state={{ patientUuid, filter }} />
             </div>
           </TabPanel>
         </TabPanels>

--- a/packages/esm-ohri-core-app/package.json
+++ b/packages/esm-ohri-core-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohri/openmrs-esm-ohri-core-app",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "A custom microfrontend for OpenMRS HIV Reference Implementation (OHRI)",
   "browser": "dist/ohri-core-app.js",
   "main": "src/index.ts",
@@ -39,7 +39,7 @@
     "moment": "^2.29.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",

--- a/packages/esm-ohri-core-app/src/index.ts
+++ b/packages/esm-ohri-core-app/src/index.ts
@@ -1,5 +1,4 @@
 import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle, provide } from '@openmrs/esm-framework';
-import { backendDependencies } from './openmrs-backend-dependencies';
 import ohriDashboardsConfig from './ohri-core-config';
 import {
   createOHRIPatientChartSideNavLink,
@@ -14,130 +13,65 @@ import {
   serviceQueuesDashboardMeta,
 } from './dashboard.meta';
 
-const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
+export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
-function setupOpenMRS() {
-  const moduleName = '@ohri/openmrs-esm-ohri-core-app';
+const moduleName = '@ohri/openmrs-esm-ohri-core-app';
 
-  const options = {
-    featureName: 'ohri-core',
-    moduleName,
-  };
+const options = {
+  featureName: 'ohri-core',
+  moduleName,
+};
 
+export function startupApp() {
   defineConfigSchema(moduleName, {});
-
-  // Load configurations
   provide(ohriDashboardsConfig);
-
-  return {
-    pages: [
-      {
-        load: getAsyncLifecycle(() => import('./root'), options),
-        route: /^dashboard/,
-      },
-      {
-        load: getAsyncLifecycle(() => import('./root'), options),
-        route: /^home/,
-      },
-    ],
-    extensions: [
-      {
-        id: 'home-dashboard-ext',
-        slot: 'dashboard-links-slot',
-        load: getSyncLifecycle(createOHRIDashboardLink(homeDashboardMeta), options),
-        meta: homeDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'ohri-patient-list',
-        slot: 'ohri-home-dashboard-slot',
-        load: getSyncLifecycle(PatientListTable, {
-          featureName: 'home',
-          moduleName,
-        }),
-        meta: homeDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'appointments-ohri-dashboard-ext',
-        slot: 'dashboard-links-slot',
-        load: getSyncLifecycle(createOHRIDashboardLink(appointmentsDashboardMeta), options),
-        meta: appointmentsDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'ohri-appointments-dashboard',
-        slot: 'ohri-appointments-dashboard-slot',
-        load: getAsyncLifecycle(() => import('./ohri-dashboard/appointments/appointments-dashboard.component'), {
-          featureName: 'appointments-dashboard',
-          moduleName,
-        }),
-        meta: appointmentsDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'dispensing-ohri-dashboard-ext',
-        slot: 'dashboard-links-slot',
-        load: getSyncLifecycle(createOHRIDashboardLink(dispensingDashboardMeta), options),
-        meta: dispensingDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'ohri-dispensing-dashboard',
-        slot: 'ohri-dispensing-dashboard-slot',
-        load: getAsyncLifecycle(() => import('./ohri-dashboard/dispensing/dispensing-dashboard.component'), {
-          featureName: 'dispensing-dashboard',
-          moduleName,
-        }),
-        meta: dispensingDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'service-queues-ohri-dashboard-ext',
-        slot: 'dashboard-links-slot',
-        load: getSyncLifecycle(createOHRIDashboardLink(serviceQueuesDashboardMeta), options),
-        meta: serviceQueuesDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'ohri-service-queues-dashboard',
-        slot: 'ohri-service-queues-dashboard-slot',
-        load: getAsyncLifecycle(() => import('./ohri-dashboard/service-queues/service-queues-dashboard.component'), {
-          featureName: 'service-queues-dashboard',
-          moduleName,
-        }),
-        meta: serviceQueuesDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'ohri-nav-items-ext',
-        slot: 'ohri-nav-items-slot',
-        load: getAsyncLifecycle(() => import('./ohri-dashboard/side-menu/ohri-dashboard-side-nav.component'), {
-          featureName: 'nav-items',
-          moduleName,
-        }),
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'clinical-views-divider',
-        slot: 'patient-chart-dashboard-slot',
-        load: getSyncLifecycle(createOHRIPatientChartSideNavLink(patientChartDivider_dashboardMeta), options),
-        meta: patientChartDivider_dashboardMeta,
-        online: true,
-        offline: true,
-        order: 20,
-      },
-    ],
-  };
 }
 
-export { backendDependencies, importTranslation, setupOpenMRS };
+export const dashboard = getAsyncLifecycle(() => import('./root'), options);
+
+export const homeDashboard = getSyncLifecycle(createOHRIDashboardLink(homeDashboardMeta), options);
+
+export const patientList = getSyncLifecycle(PatientListTable, {
+  featureName: 'home',
+  moduleName,
+});
+
+export const appointmentsLink = getSyncLifecycle(createOHRIDashboardLink(appointmentsDashboardMeta), options);
+export const appointmentsDashboard = getAsyncLifecycle(
+  () => import('./ohri-dashboard/appointments/appointments-dashboard.component'),
+  {
+    featureName: 'appointments-dashboard',
+    moduleName,
+  },
+);
+
+export const dispensingLink = getSyncLifecycle(createOHRIDashboardLink(dispensingDashboardMeta), options);
+export const dispensingDashboard = getAsyncLifecycle(
+  () => import('./ohri-dashboard/dispensing/dispensing-dashboard.component'),
+  {
+    featureName: 'dispensing-dashboard',
+    moduleName,
+  },
+);
+
+export const serviceQueuesLink = getSyncLifecycle(createOHRIDashboardLink(serviceQueuesDashboardMeta), options);
+export const serviceQueuesDashboard = getAsyncLifecycle(
+  () => import('./ohri-dashboard/service-queues/service-queues-dashboard.component'),
+  {
+    featureName: 'service-queues-dashboard',
+    moduleName,
+  },
+);
+
+export const ohriNavItems = getAsyncLifecycle(
+  () => import('./ohri-dashboard/side-menu/ohri-dashboard-side-nav.component'),
+  {
+    featureName: 'nav-items',
+    moduleName,
+  },
+);
+
+export const ohriClinicalViewsDivider = getSyncLifecycle(
+  createOHRIPatientChartSideNavLink(patientChartDivider_dashboardMeta),
+  options,
+);

--- a/packages/esm-ohri-core-app/src/ohri-dashboard/appointments/appointments-dashboard.component.tsx
+++ b/packages/esm-ohri-core-app/src/ohri-dashboard/appointments/appointments-dashboard.component.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { attach, detach, ExtensionSlot } from '@openmrs/esm-framework';
 
 const AppointmentsDashboard = () => {
-  return <ExtensionSlot extensionSlotName="ohri-dashboard-appointments-slot" state={{}} />;
+  return <ExtensionSlot name="ohri-dashboard-appointments-slot" state={{}} />;
 };
 
 export default AppointmentsDashboard;

--- a/packages/esm-ohri-core-app/src/ohri-dashboard/ohri-dashboard.component.tsx
+++ b/packages/esm-ohri-core-app/src/ohri-dashboard/ohri-dashboard.component.tsx
@@ -50,9 +50,9 @@ const OHRIDashboard = () => {
           />
         );
       })}
-      {isDesktop(layout) && <ExtensionSlot extensionSlotName="ohri-nav-items-slot" key={layout} />}
+      {isDesktop(layout) && <ExtensionSlot name="ohri-nav-items-slot" key={layout} />}
       <div className={` ${styles.dashboardContent}`}>
-        {currentDashboard && <ExtensionSlot extensionSlotName={currentDashboard.slot} state={state} />}
+        {currentDashboard && <ExtensionSlot name={currentDashboard.slot} state={state} />}
       </div>
     </div>
   );

--- a/packages/esm-ohri-core-app/src/ohri-dashboard/service-queues/service-queues-dashboard.component.tsx
+++ b/packages/esm-ohri-core-app/src/ohri-dashboard/service-queues/service-queues-dashboard.component.tsx
@@ -7,7 +7,7 @@ const ServiceQueuesDashboard = () => {
     return () => detach('ohri-dashboard-service-queues-slot', 'service-queues-dashboard');
   }, []);
 
-  return <ExtensionSlot extensionSlotName="ohri-dashboard-service-queues-slot" state={{}} />;
+  return <ExtensionSlot name="ohri-dashboard-service-queues-slot" state={{}} />;
 };
 
 export default ServiceQueuesDashboard;

--- a/packages/esm-ohri-core-app/src/routes.json
+++ b/packages/esm-ohri-core-app/src/routes.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "backendDependencies": {
+    "webservices.rest": "^2.24.0"
+  },
+  "pages": [
+    {
+      "component": "dashboard",
+      "route": "dashboard"
+    },
+    {
+      "component": "dashboard",
+      "route": "home"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "home-dashboard-ext",
+      "slot": "dashboard-links-slot",
+      "component": "homeDashboard"
+    },
+    {
+      "name": "ohri-patient-list",
+      "slot": "ohri-home-dashboard-slot",
+      "component": "patientList"
+    },
+    {
+      "name": "appointments-ohri-dashboard-ext",
+      "slot": "dashboard-links-slot",
+      "component": "appointmentsLink"
+    },
+    {
+      "name": "ohri-appointments-dashboard",
+      "slot": "ohri-appointments-dashboard-slot",
+      "component": "appointmentsDashboard"
+    },
+    {
+      "name": "dispensing-ohri-dashboard-ext",
+      "slot": "dashboard-links-slot",
+      "component": "dispensingLink"
+    },
+    {
+      "name": "ohri-dispensing-dashboard",
+      "slot": "ohri-dispensing-dashboard-slot",
+      "component": "dispensingDashboard"
+    },
+    {
+      "name": "service-queues-ohri-dashboard-ext",
+      "slot": "dashboard-links-slot",
+      "component": "serviceQueuesLink"
+    },
+    {
+      "name": "ohri-service-queues-dashboard",
+      "slot": "ohri-service-queues-dashboard-slot",
+      "component": "serviceQueuesDashboard"
+    },
+    {
+      "name": "ohri-nav-items-ext",
+      "slot": "ohri-nav-items-slot",
+      "component": "ohriNavItems"
+    },
+    {
+      "name": "clinical-views-divider",
+      "slot": "patient-chart-dashboard-slot",
+      "component": "ohriClinicalViewsDivider",
+      "order": 20
+    }
+
+  ]
+}

--- a/packages/esm-ohri-core-app/src/routes.json
+++ b/packages/esm-ohri-core-app/src/routes.json
@@ -65,6 +65,5 @@
       "component": "ohriClinicalViewsDivider",
       "order": 20
     }
-
   ]
 }

--- a/packages/esm-ohri-pmtct-app/package.json
+++ b/packages/esm-ohri-pmtct-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohri/openmrs-esm-ohri-pmtct",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "PMTCT microfrontend for OpenMRS HIV Reference Implementation (OHRI)",
   "browser": "dist/ohri-pmtct-app.js",
   "main": "src/index.ts",
@@ -37,7 +37,7 @@
     "@carbon/react": "^1.13.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "@openmrs/esm-patient-common-lib": "4.x",
     "dayjs": "^1.8.16",
     "react": "^18.2.0",

--- a/packages/esm-ohri-pmtct-app/src/index.ts
+++ b/packages/esm-ohri-pmtct-app/src/index.ts
@@ -1,5 +1,4 @@
 import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
-import { backendDependencies } from './openmrs-backend-dependencies';
 import {
   mchSummaryDashboardMeta,
   mchFolderMeta,
@@ -17,17 +16,18 @@ import {
   OHRIWelcomeSection,
 } from '@ohri/openmrs-esm-ohri-commons-lib';
 
-const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
-
-require('./root.scss');
+export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
 export const moduleName = '@ohri/openmrs-esm-ohri-pmtct';
 
-function setupOpenMRS() {
-  const options = {
-    featureName: 'ohri-pmtct',
-    moduleName,
-  };
+require('./root.scss');
+
+const options = {
+  featureName: 'ohri-pmtct',
+  moduleName,
+};
+
+export function startupApp() {
   defineConfigSchema(moduleName, {});
   registerPostSubmissionAction({
     id: 'MotherToChildLinkageSubmissionAction',
@@ -41,113 +41,59 @@ function setupOpenMRS() {
     id: 'ArtSubmissionAction',
     load: () => import('./post-submission-actions/art-linkage-action'),
   });
-
-  return {
-    pages: [],
-    extensions: [
-      {
-        id: 'mch',
-        slot: 'patient-chart-dashboard-slot',
-        load: getSyncLifecycle(createDashboardGroup(mchFolderMeta), options),
-        meta: mchFolderMeta,
-        online: true,
-        offline: true,
-        order: 25,
-      },
-      {
-        id: 'mch-summary-dashboard',
-        slot: 'mch-slot',
-        load: getSyncLifecycle(createDashboardLinkWithCustomTitle(mchSummaryDashboardMeta), options),
-        meta: mchSummaryDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'mch-summary-ext',
-        slot: 'mch-summary-slot',
-        load: getAsyncLifecycle(() => import('./views/mch-summary/mch-summary.component'), {
-          featureName: 'mch-summary',
-          moduleName,
-        }),
-      },
-      {
-        id: 'maternal-Health-dashboard',
-        slot: 'mch-slot',
-        load: getSyncLifecycle(createConditionalDashboardLink(maternalVisitsDashboardMeta), options),
-        meta: maternalVisitsDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'maternal-visits-summary-ext',
-        slot: 'maternal-visits-summary-slot',
-        load: getAsyncLifecycle(() => import('./views/maternal-health/maternal-health.component'), {
-          featureName: 'maternal-visits',
-          moduleName,
-        }),
-      },
-      {
-        id: 'child-visits-dashboard',
-        slot: 'mch-slot',
-        load: getSyncLifecycle(createConditionalDashboardLink(childVisitsDashboardMeta), options),
-        meta: childVisitsDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'child-visits-summary-ext',
-        slot: 'child-visits-summary-slot',
-        load: getAsyncLifecycle(() => import('./views/child-health/child-health.component'), {
-          featureName: 'child-visits',
-          moduleName,
-        }),
-      },
-      {
-        id: 'mother-child-health-results-dashboard',
-        slot: 'mother-child-health-dashboard-slot',
-        load: getSyncLifecycle(OHRIHome, {
-          featureName: 'mother child health results dashboard',
-          moduleName,
-        }),
-        meta: motherChildDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'pmtct-home-header-slot',
-        slot: 'pmtct-home-header-slot',
-        title: 'Maternal Child Health',
-        load: getSyncLifecycle(OHRIWelcomeSection, {
-          featureName: 'pmtct-home-header',
-          moduleName,
-        }),
-      },
-      {
-        id: 'pmtct-home-tabs-ext',
-        slot: 'pmtct-home-tabs-slot',
-        load: getAsyncLifecycle(() => import('./views/summary-tabs/mother-child-summary-tabs.component'), {
-          featureName: 'pmtct-home-tabs',
-          moduleName,
-        }),
-      },
-      {
-        id: 'maternal-child-health-results-summary',
-        slot: 'dashboard-slot',
-        load: getSyncLifecycle(createOHRIDashboardLink(motherChildDashboardMeta), options),
-        meta: motherChildDashboardMeta,
-        online: true,
-        offline: true,
-      },
-      {
-        id: 'pmtct-home-tile-ext',
-        slot: 'pmtct-home-tiles-slot',
-        load: getAsyncLifecycle(() => import('./views/summary-tabs/maternal-child-summary-tiles.component'), {
-          featureName: 'pmtct-home-tiles',
-          moduleName,
-        }),
-      },
-    ],
-  };
 }
 
-export { backendDependencies, importTranslation, setupOpenMRS };
+export const mchDashboard = getSyncLifecycle(createDashboardGroup(mchFolderMeta), options);
+export const mchSummaryDashboardLink = getSyncLifecycle(
+  createDashboardLinkWithCustomTitle(mchSummaryDashboardMeta),
+  options,
+);
+export const mchSummaryDashboard = getAsyncLifecycle(() => import('./views/mch-summary/mch-summary.component'), {
+  featureName: 'mch-summary',
+  moduleName,
+});
+
+export const maternalVisitsDashboardLink = getSyncLifecycle(
+  createConditionalDashboardLink(maternalVisitsDashboardMeta),
+  options,
+);
+export const maternalVisitsDashboard = getAsyncLifecycle(
+  () => import('./views/maternal-health/maternal-health.component'),
+  {
+    featureName: 'maternal-visits',
+    moduleName,
+  },
+);
+
+export const childVisitsDashboardLink = getSyncLifecycle(
+  createConditionalDashboardLink(childVisitsDashboardMeta),
+  options,
+);
+export const childVisitsDashboard = getAsyncLifecycle(() => import('./views/child-health/child-health.component'), {
+  featureName: 'child-visits',
+  moduleName,
+});
+
+export const maternalChildDashboardLink = getSyncLifecycle(createOHRIDashboardLink(motherChildDashboardMeta), options);
+export const maternalChildDashboard = getSyncLifecycle(OHRIHome, {
+  featureName: 'mother child health results dashboard',
+  moduleName,
+});
+export const pmtctDashboardHeader = getSyncLifecycle(OHRIWelcomeSection, {
+  featureName: 'pmtct-home-header',
+  moduleName,
+});
+export const pmtctDashboardTiles = getAsyncLifecycle(
+  () => import('./views/summary-tabs/maternal-child-summary-tiles.component'),
+  {
+    featureName: 'pmtct-home-tiles',
+    moduleName,
+  },
+);
+export const pmtctDashboardTabs = getAsyncLifecycle(
+  () => import('./views/summary-tabs/mother-child-summary-tabs.component'),
+  {
+    featureName: 'pmtct-home-tabs',
+    moduleName,
+  },
+);

--- a/packages/esm-ohri-pmtct-app/src/routes.json
+++ b/packages/esm-ohri-pmtct-app/src/routes.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "backendDependencies": {
+    "webservices.rest": "^2.24.0"
+  },
+  "pages": [
+  ],
+  "extensions": [
+    {
+      "name": "mch",
+      "slot": "patient-chart-dashboard-slot",
+      "component": "mchDashboard",
+      "order": 25
+    },
+    {
+      "name": "mch-summary-dashboard",
+      "slot": "mch-slot",
+      "component": "mchSummaryDashboardLink"
+    },
+    {
+      "name": "mch-summary-ext",
+      "slot": "mch-summary-slot",
+      "component": "mchSummaryDashboard"
+    },
+    {
+      "name": "maternal-visits-dashboard",
+      "slot": "mch-slot",
+      "component": "maternalVisitsDashboardLink"
+    },
+    {
+      "name": "maternal-visits-summary-ext",
+      "slot": "maternal-visits-summary-slot",
+      "component": "maternalVisitsDashboard"
+    },
+    {
+      "name": "child-visits-dashboard",
+      "slot": "mch-slot",
+      "component": "childVisitsDashboardLink"
+    },
+    {
+      "name": "child-visits-summary-ext",
+      "slot": "child-visits-summary-slot",
+      "component": "childVisitsDashboard"
+    },
+    {
+      "name": "maternal-child-health-results-summary",
+      "slot": "dashboard-slot",
+      "component": "maternalChildDashboardLink"
+    },
+    {
+      "name": "mother-child-health-results-dashboard",
+      "slot": "mother-child-health-dashboard-slot",
+      "component": "maternalChildDashboard"
+    },
+    {
+      "name": "pmtct-home-header-slot",
+      "slot": "pmtct-home-header-slot",
+      "component": "pmtctDashboardHeader"
+    },
+    {
+      "name": "pmtct-home-tile-ext",
+      "slot": "pmtct-home-tile-slot",
+      "component": "pmtctDashboardTiles"
+    },
+    {
+      "name": "pmtct-home-tabs-ext",
+      "slot": "pmtct-home-tabs-slot",
+      "component": "pmtctDashboardTabs"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.1, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.17.9":
+"@babel/core@npm:^7.11.1, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3":
   version: 7.20.5
   resolution: "@babel/core@npm:7.20.5"
   dependencies:
@@ -1312,7 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.17.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.20.5
   resolution: "@babel/types@npm:7.20.5"
   dependencies:
@@ -1499,20 +1499,6 @@ __metadata:
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
   checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm@npm:0.15.16":
-  version: 0.15.16
-  resolution: "@esbuild/android-arm@npm:0.15.16"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "@esbuild/linux-loong64@npm:0.15.16"
-  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -2346,6 +2332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/source-map@npm:^0.3.3":
+  version: 0.3.4
+  resolution: "@jridgewell/source-map@npm:0.3.4"
+  checksum: 87fae5d8a81bbe5d691f2a415588ee020ec3b858674f675c206f0f7060d820c49dcc755ffd27cc8467e4f50576d7b5b7fc86d34d5e53a879ce7440deef732948
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
@@ -2360,6 +2353,16 @@ __metadata:
     "@jridgewell/resolve-uri": 3.1.0
     "@jridgewell/sourcemap-codec": 1.4.14
   checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.17":
+  version: 0.3.18
+  resolution: "@jridgewell/trace-mapping@npm:0.3.18"
+  dependencies:
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 0572669f855260808c16fe8f78f5f1b4356463b11d3f2c7c0b5580c8ba1cbf4ae53efe9f627595830856e57dbac2325ac17eb0c3dd0ec42102e6f227cc289c02
   languageName: node
   linkType: hard
 
@@ -3501,7 +3504,7 @@ __metadata:
     "@carbon/react": ^1.13.0
     webpack: ^5.74.0
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
@@ -3526,7 +3529,7 @@ __metadata:
     webpack-cli: ^5.1.1
     yup: ^0.29.1
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
@@ -3543,7 +3546,7 @@ __metadata:
     moment: ^2.29.1
     webpack: ^5.74.0
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
@@ -3561,7 +3564,7 @@ __metadata:
     moment: ^2.29.1
     webpack: ^5.74.0
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
@@ -3585,7 +3588,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@carbon/react": 1.x
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/openmrs-form-engine-lib": 1.x
     react: ^18.2.0
     react-i18next: ^11.18.6
@@ -3601,7 +3604,7 @@ __metadata:
     moment: ^2.29.1
     webpack: ^5.74.0
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
@@ -3617,7 +3620,7 @@ __metadata:
     "@carbon/react": ^1.13.0
     webpack: ^5.74.0
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     "@openmrs/esm-patient-common-lib": 4.x
     dayjs: ^1.8.16
     react: ^18.2.0
@@ -3688,28 +3691,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-api@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-api@npm:4.3.1-pre.632"
+"@openmrs/esm-api@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-api@npm:5.0.3-pre.857"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
   peerDependencies:
     "@openmrs/esm-config": 4.x
     "@openmrs/esm-error-handling": 4.x
-  checksum: e2a40bb5d59849ea6c1cf9e43c28a089d4723221686526b5033019e193b81bc3284973a0ec16b4cb8abb3c0fc92ece9f30d3788af874c0e1e59b7c1e06d91ec1
+    "@openmrs/esm-offline": 4.x
+  checksum: afc2bc581c9d4427da14124e72436a8d21dcb1ebdfd08db5a9890eebdc7b519cf8283ecc09857887e9e2b7939bfb93d46eb5767b4101022d6c81c63a31163c85
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-app-shell@npm:4.3.1-pre.632"
+"@openmrs/esm-app-shell@npm:5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-app-shell@npm:5.0.3-pre.857"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-framework": 4.3.1-pre.632
-    "@openmrs/esm-styleguide": 4.3.1-pre.632
+    "@openmrs/esm-framework": 5.0.3-pre.857
+    "@openmrs/esm-styleguide": 5.0.3-pre.857
     dayjs: ^1.10.4
     dexie: ^3.0.3
+    html-webpack-plugin: ^5.5.0
     i18next: ^19.6.0
     i18next-browser-languagedetector: ^4.3.1
     i18next-icu: ^1.4.2
@@ -3721,52 +3726,64 @@ __metadata:
     react-router-dom: ^6.3.0
     rxjs: ^6.5.3
     single-spa: ^5.9.2
+    swc-loader: ^0.2.3
     systemjs: ^6.8.3
+    webpack: ^5.88.0
+    webpack-pwa-manifest: ^4.3.0
     workbox-core: ^6.1.5
     workbox-routing: ^6.1.5
     workbox-strategies: ^6.1.5
+    workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: ea47942c5dfffa6b8daab91a3885f58413c7bf30659bd9ee48794985b9185bc8bc713e7d2e3d469575b4bfa3dd66b21e3caa48f8651f627bef372528b80ffd39
+  checksum: 3188bfb38046db620a3e2c9c4aeff709b661303e3af3e189aa78bb72176a729a8d2c7f80508ea0c0ee36ce75066938331c25b516a62ddafa9fdee7bc0cf60bba
   languageName: node
   linkType: hard
 
-"@openmrs/esm-breadcrumbs@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-breadcrumbs@npm:4.3.1-pre.632"
+"@openmrs/esm-breadcrumbs@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-breadcrumbs@npm:5.0.3-pre.857"
   dependencies:
     path-to-regexp: 6.1.0
   peerDependencies:
     "@openmrs/esm-state": 4.x
-  checksum: da767054e4eb4bcf9fb2fd1823f23b6735bba4edf442058c1fc83200cf4d8ca44b89b5437769bfa802076bdc341f41e5e1a2ec9d91772d677eabdb1a6f96760b
+  checksum: 956ca03cbbed3b5fc5e0d6bcc1661f707400cdb20a56010426d4325c7d304629a4e14b4a4239fe6861d149900c5e80e5290e71b6e56b0cf0cc4ad4102d34e562
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-config@npm:4.3.1-pre.632"
+"@openmrs/esm-config@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-config@npm:5.0.3-pre.857"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 4.x
     "@openmrs/esm-state": 4.x
     single-spa: 5.x
-    systemjs: 6.x
-  checksum: ce852f9931cc9ebeada85be4a88173cff3feb4b6fcb6fec3ce6bb8edb64694cf2140e3392c3358052ace2adca8660920b10d6bd0484d0e2c4f799c5a1f71765c
+  checksum: db8305f7eb2d08c5cc5ccf76ee9e3c875987440ce03113286bfbc8dd879b285706278b6447eb41aa87355b1987dc089ec94626d25950bb0fbaaa4b87bb3fd094
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-error-handling@npm:4.3.1-pre.632"
+"@openmrs/esm-dynamic-loading@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.0.3-pre.857"
   peerDependencies:
     "@openmrs/esm-globals": 4.x
-  checksum: 6ef62ed9da2b11908df4d1ebc766bf431867db1c5d56c2bd4f376f0cd028fb12161a540b89e409946a9ab9e1e8377dc2a1cfa61fae0f05a19ca8b7eb60ac0011
+  checksum: f5bf1cd329ae3c72e11a7b096e41d163d5c6aaa725e7dc5b63128f85772a9ba11d4398140c5d53863da271f93d92083240b6cd8dea1a22ec55ea6e5b54b2825d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-extensions@npm:4.3.1-pre.632"
+"@openmrs/esm-error-handling@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-error-handling@npm:5.0.3-pre.857"
+  peerDependencies:
+    "@openmrs/esm-globals": 4.x
+  checksum: 342ae403800f0dab608cd6fa469a4a665bbb8eb485e86d1c960207b7b7075d295b8afb7c293280e8a176f57db54753e37dd684bdffd23b85965a385711cbf387
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-extensions@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-extensions@npm:5.0.3-pre.857"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -3774,46 +3791,55 @@ __metadata:
     "@openmrs/esm-config": 4.x
     "@openmrs/esm-state": 4.x
     single-spa: 5.x
-  checksum: 8307dd764e349c5cd55dce2c65a3d7d9f1142b20b06d36d1b7dac15e8f4244b0a80c8025ec89a3d5deccb2e1a8326caf7a33efb8db70b32ff108463b132bfa50
+  checksum: 09cf5915701c4ebb6e3011eb28550add1d0e77aedfd8619d102fa482296964f6705edbc8d23d2ad20632929f351afaa5e30a9ce0a0c4468e6d799e58f056e58e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:4.3.1-pre.632, @openmrs/esm-framework@npm:next":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-framework@npm:4.3.1-pre.632"
+"@openmrs/esm-framework@npm:5.0.3-pre.857, @openmrs/esm-framework@npm:next":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-framework@npm:5.0.3-pre.857"
   dependencies:
-    "@openmrs/esm-api": ^4.3.1-pre.632
-    "@openmrs/esm-breadcrumbs": ^4.3.1-pre.632
-    "@openmrs/esm-config": ^4.3.1-pre.632
-    "@openmrs/esm-error-handling": ^4.3.1-pre.632
-    "@openmrs/esm-extensions": ^4.3.1-pre.632
-    "@openmrs/esm-globals": ^4.3.1-pre.632
-    "@openmrs/esm-offline": ^4.3.1-pre.632
-    "@openmrs/esm-react-utils": ^4.3.1-pre.632
-    "@openmrs/esm-state": ^4.3.1-pre.632
-    "@openmrs/esm-styleguide": ^4.3.1-pre.632
-    "@openmrs/esm-utils": ^4.3.1-pre.632
+    "@openmrs/esm-api": ^5.0.3-pre.857
+    "@openmrs/esm-breadcrumbs": ^5.0.3-pre.857
+    "@openmrs/esm-config": ^5.0.3-pre.857
+    "@openmrs/esm-dynamic-loading": ^5.0.3-pre.857
+    "@openmrs/esm-error-handling": ^5.0.3-pre.857
+    "@openmrs/esm-extensions": ^5.0.3-pre.857
+    "@openmrs/esm-globals": ^5.0.3-pre.857
+    "@openmrs/esm-offline": ^5.0.3-pre.857
+    "@openmrs/esm-react-utils": ^5.0.3-pre.857
+    "@openmrs/esm-state": ^5.0.3-pre.857
+    "@openmrs/esm-styleguide": ^5.0.3-pre.857
+    "@openmrs/esm-utils": ^5.0.3-pre.857
     dayjs: ^1.10.7
-  checksum: ad2541521f66ae801898dfdfafb36f1676ff63ea6d2324b84dcf8c007e21aeb76d5563fce4b2e00aaf48ed8af2c424dccf29da63628a9aabd4e04bacc07a9e11
+  peerDependencies:
+    dayjs: 1.x
+    i18next: 19.x
+    react: 18.x
+    react-dom: 18.x
+    react-i18next: 11.x
+    rxjs: 6.x
+    single-spa: 5.x
+  checksum: 085d772e5de0f071c2a21388c50a649b2791fa76526aa00046465b755cf7c44a10541ad04b70169ab9cdca29a0fdb2886cc894aa59faa5a5344699ab3e81ee7c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-globals@npm:4.3.1-pre.632"
+"@openmrs/esm-globals@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-globals@npm:5.0.3-pre.857"
   peerDependencies:
     single-spa: 5.x
-  checksum: fabf4c8eb7f6c20a1f6d63ce88cb709558b0b2811bee7b8508f404103cba93318b1e5bf91cfba9468953307cf5972483dce15b560ab733a2dbb9a7a588c5e20e
+  checksum: 8a3c36c63a525d21aa8eb9d8bd607d947750326c925023934965cd2f06ed4a851b7b9227145a0f2842b1b574e1a63f07a9103fcc5b01c7aa0e0dbbf6b8b5df0a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-offline@npm:4.3.1-pre.632"
+"@openmrs/esm-offline@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-offline@npm:5.0.3-pre.857"
   dependencies:
     dexie: ^3.0.3
-    lodash-es: 4.17.21
-    uuid: ^8.3.2
+    lodash-es: ^4.17.21
+    uuid: ^9.0.0
     workbox-window: ^6.1.5
   peerDependencies:
     "@openmrs/esm-api": 4.x
@@ -3821,7 +3847,7 @@ __metadata:
     "@openmrs/esm-state": 4.x
     "@openmrs/esm-styleguide": 4.x
     rxjs: 6.x
-  checksum: 4dd5e298b8e65db645406f5660ca48ebe8c8bfc8ed0175ae359b99f27791ee1cb0485f66b1bd1dd4d1009e496f99ed73921803b11538f504904cb3837f436170
+  checksum: 23077e2805cbbc088ab21e9f64a1e6f91a76b3ba1ed7d9f7964a6bfeabd301a163e3435c47f2d135045214c8579062e2f8fb8d691646750ac80c80f517878eee
   languageName: node
   linkType: hard
 
@@ -3840,12 +3866,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-react-utils@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-react-utils@npm:4.3.1-pre.632"
+"@openmrs/esm-react-utils@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-react-utils@npm:5.0.3-pre.857"
   dependencies:
     lodash-es: ^4.17.21
-    single-spa-react: ^5.0.0
+    single-spa-react: ~5.0.0
     swr: ^2.0.1
   peerDependencies:
     "@openmrs/esm-api": 4.x
@@ -3858,54 +3884,52 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     react-i18next: 11.x
-  checksum: 725dce7855c6b2a57ca660939593da6a0dc8e91735d5008644db9dc7575de581c46af4d561e56c75aeba7cb4cf65f46a4df81c49972196e6f1002c29ddb108e8
+  checksum: 11986d331ae9e55ef4683c9d8e7a64dfa7ac34ad0a1bf6fa5c3e6432a250a90f94bdc9fcd45efcf7938c018f4c9187db7884adb583a6ec53eb9e473d677c8518
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-state@npm:4.3.1-pre.632"
+"@openmrs/esm-state@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-state@npm:5.0.3-pre.857"
   dependencies:
-    unistore: ^3.5.2
-  checksum: a5b4ea229feda38271fb42b0ad5732edc79ff98e0b319745b366c785a070d7ac27ff380bbc955b4ab87561f5ad30d707b0a2310289f23c5d9719d91dc755688a
+    zustand: ^4.3.6
+  checksum: b4261a1b9f2e514ded2c520ccbc48a7864aaba7b8f84487947be1ccadedb9cca8afb390d50d3367b4f0350692b0082f8e7d84f43ff3efebfc59562bb32a3f611
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:4.3.1-pre.632, @openmrs/esm-styleguide@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-styleguide@npm:4.3.1-pre.632"
+"@openmrs/esm-styleguide@npm:5.0.3-pre.857, @openmrs/esm-styleguide@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-styleguide@npm:5.0.3-pre.857"
   dependencies:
     "@carbon/charts": ^1.6.3
     "@carbon/react": ^1.12.0
     d3: ^7.8.0
     lodash-es: ^4.17.21
   peerDependencies:
-    "@openmrs/esm-extensions": 4.x
-    "@openmrs/esm-react-utils": 4.x
-    "@openmrs/esm-state": 4.x
+    "@openmrs/esm-framework": 4.x
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 0a23d3cc46989e0a2f19c9f21c59e0d1114c2e9d4eeae05127bfc4b09489db7ddf6c51685c0bd25bee807cafcc798c09c7178e637679bd23b3c869e95e7ed152
+  checksum: 19d6a768a6f22f2ded1887b795539e6f731c0db8811d8368b1ca8c08ab37ac2c039901e8093ad675e9282bcb7ab08994307ad38c1aa88ed1995daf394cc2b54b
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:^4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/esm-utils@npm:4.3.1-pre.632"
+"@openmrs/esm-utils@npm:^5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/esm-utils@npm:5.0.3-pre.857"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: a3e413ebbd42fa259c13af4245295dcc0adda8fa5d3e45db2bf5ecc227b47dcfc706e271026e9b74dbfd0a058bdcee14914204766858303f9fbd57add58faf36
+  checksum: 270254ecac413d179c2b9f67d4732d2db90f6c2a4a96f912080ec757f168363292b6747069020738ffcc68e1327e23a64e33df4040eb355ba5f9af932cc3c414
   languageName: node
   linkType: hard
 
 "@openmrs/openmrs-form-engine-lib@npm:next":
-  version: 1.0.0-pre.271
-  resolution: "@openmrs/openmrs-form-engine-lib@npm:1.0.0-pre.271"
+  version: 1.0.0-pre.277
+  resolution: "@openmrs/openmrs-form-engine-lib@npm:1.0.0-pre.277"
   dependencies:
     ace-builds: ^1.4.12
     enzyme: ^3.11.0
@@ -3927,33 +3951,31 @@ __metadata:
     react: ^18.2.0
     react-i18next: 11.x
     rxjs: 6.x
-  checksum: cf65c91a499266ddcf589d967a1f476393e7c3bc665848abb3cdf2b26229452e13030416c1574d8e74ffa8a9ffb8f45d46bf96025ed40eaf722e6009ce5e6f79
+  checksum: 6c577a7f34bed4651c51d6717fa0a38127bb27b1a325ed719e73a580c0c0023bb73dc58ce8a9914779a6bfe277258569a635ce57214908f5ca5cf6f6f0e06ca0
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:4.3.1-pre.632":
-  version: 4.3.1-pre.632
-  resolution: "@openmrs/webpack-config@npm:4.3.1-pre.632"
+"@openmrs/webpack-config@npm:5.0.3-pre.857":
+  version: 5.0.3-pre.857
+  resolution: "@openmrs/webpack-config@npm:5.0.3-pre.857"
   dependencies:
-    "@babel/core": ^7.17.9
-    "@babel/types": ^7.17.0
-    "@swc/core": ^1.2.165
+    "@swc/core": ^1.3.58
     babel-preset-minify: ^0.5.1
     clean-webpack-plugin: ^4.0.0
+    copy-webpack-plugin: ^11.0.0
     css-loader: ^5.2.4
     fork-ts-checker-webpack-plugin: ^6.5.0
     lodash: ^4.17.21
     sass: ^1.44.0
     sass-loader: ^12.3.0
     style-loader: ^3.3.1
-    swc-loader: ^0.1.15
-    systemjs-webpack-interop: ^2.3.7
-    webpack: ^5.75.0
+    swc-loader: ^0.2.3
+    webpack: ^5.88.0
     webpack-bundle-analyzer: ^4.5.0
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: d3dc984983d9b76e663c65eaadfe9bef7e03bfe9be92380228c575d999e7a7687f0569c57c2317c084a411fc8eee9fa3d789fe0df655f9d25e9d1d8b7a5104d4
+  checksum: 57349c2690bd8c4deb493a97ae5c62b5d84303f81ba30595565fc335921b2339eb3318538a6fbbffb6004d2023c1ce5d53dc23c9480389c8af0b8bd0a2e4ec62
   languageName: node
   linkType: hard
 
@@ -4121,9 +4143,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-darwin-arm64@npm:1.3.67"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-x64@npm:1.3.20":
   version: 1.3.20
   resolution: "@swc/core-darwin-x64@npm:1.3.20"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-darwin-x64@npm:1.3.67"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -4135,9 +4171,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm-gnueabihf@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.67"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm64-gnu@npm:1.3.20":
   version: 1.3.20
   resolution: "@swc/core-linux-arm64-gnu@npm:1.3.20"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.67"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -4149,9 +4199,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm64-musl@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-linux-arm64-musl@npm:1.3.67"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-x64-gnu@npm:1.3.20":
   version: 1.3.20
   resolution: "@swc/core-linux-x64-gnu@npm:1.3.20"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-linux-x64-gnu@npm:1.3.67"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -4163,9 +4227,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-x64-musl@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-linux-x64-musl@npm:1.3.67"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-arm64-msvc@npm:1.3.20":
   version: 1.3.20
   resolution: "@swc/core-win32-arm64-msvc@npm:1.3.20"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.67"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -4177,9 +4255,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-win32-ia32-msvc@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.67"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-x64-msvc@npm:1.3.20":
   version: 1.3.20
   resolution: "@swc/core-win32-x64-msvc@npm:1.3.20"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.3.67":
+  version: 1.3.67
+  resolution: "@swc/core-win32-x64-msvc@npm:1.3.67"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4222,6 +4314,50 @@ __metadata:
   bin:
     swcx: run_swcx.js
   checksum: 646c37e3521f04cd08061ab67a4388959e4b234c38eba2eb9fe0fd615dedb6ff9412264789e58af7c2d24b3e5a7ea456efd060e3760d7a91509234b5b5983ad7
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.3.58":
+  version: 1.3.67
+  resolution: "@swc/core@npm:1.3.67"
+  dependencies:
+    "@swc/core-darwin-arm64": 1.3.67
+    "@swc/core-darwin-x64": 1.3.67
+    "@swc/core-linux-arm-gnueabihf": 1.3.67
+    "@swc/core-linux-arm64-gnu": 1.3.67
+    "@swc/core-linux-arm64-musl": 1.3.67
+    "@swc/core-linux-x64-gnu": 1.3.67
+    "@swc/core-linux-x64-musl": 1.3.67
+    "@swc/core-win32-arm64-msvc": 1.3.67
+    "@swc/core-win32-ia32-msvc": 1.3.67
+    "@swc/core-win32-x64-msvc": 1.3.67
+  peerDependencies:
+    "@swc/helpers": ^0.5.0
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 89959d2402d3c9b70181c72c612e8236a7357ea9d58a32d4c0ed13bbe0b1a84257b5808efe9db2b39879fe82a7b78ea3884fad37d5ac44808f21ca01149a28ec
   languageName: node
   linkType: hard
 
@@ -4447,6 +4583,13 @@ __metadata:
   version: 0.0.51
   resolution: "@types/estree@npm:0.0.51"
   checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@types/estree@npm:1.0.1"
+  checksum: e9aa175eacb797216fafce4d41e8202c7a75555bc55232dee0f9903d7171f8f19f0ae7d5191bb1a88cb90e65468be508c0df850a9fb81b4433b293a5a749899d
   languageName: node
   linkType: hard
 
@@ -5086,10 +5229,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/ast@npm:1.11.6, @webassemblyjs/ast@npm:^1.11.5":
+  version: 1.11.6
+  resolution: "@webassemblyjs/ast@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/helper-numbers": 1.11.6
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.6
+  checksum: 38ef1b526ca47c210f30975b06df2faf1a8170b1636ce239fc5738fc231ce28389dd61ecedd1bacfc03cbe95b16d1af848c805652080cb60982836eb4ed2c6cf
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/floating-point-hex-parser@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.1"
   checksum: b8efc6fa08e4787b7f8e682182d84dfdf8da9d9c77cae5d293818bc4a55c1f419a87fa265ab85252b3e6c1fd323d799efea68d825d341a7c365c64bc14750e97
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/floating-point-hex-parser@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.6"
+  checksum: 29b08758841fd8b299c7152eda36b9eb4921e9c584eb4594437b5cd90ed6b920523606eae7316175f89c20628da14326801090167cc7fbffc77af448ac84b7e2
   languageName: node
   linkType: hard
 
@@ -5100,10 +5260,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-api-error@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-api-error@npm:1.11.6"
+  checksum: e8563df85161096343008f9161adb138a6e8f3c2cc338d6a36011aa55eabb32f2fd138ffe63bc278d009ada001cc41d263dadd1c0be01be6c2ed99076103689f
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/helper-buffer@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/helper-buffer@npm:1.11.1"
   checksum: a337ee44b45590c3a30db5a8b7b68a717526cf967ada9f10253995294dbd70a58b2da2165222e0b9830cd4fc6e4c833bf441a721128d1fe2e9a7ab26b36003ce
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-buffer@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-buffer@npm:1.11.6"
+  checksum: b14d0573bf680d22b2522e8a341ec451fddd645d1f9c6bd9012ccb7e587a2973b86ab7b89fe91e1c79939ba96095f503af04369a3b356c8023c13a5893221644
   languageName: node
   linkType: hard
 
@@ -5118,10 +5292,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-numbers@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-numbers@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser": 1.11.6
+    "@webassemblyjs/helper-api-error": 1.11.6
+    "@xtuc/long": 4.2.2
+  checksum: f4b562fa219f84368528339e0f8d273ad44e047a07641ffcaaec6f93e5b76fd86490a009aa91a294584e1436d74b0a01fa9fde45e333a4c657b58168b04da424
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/helper-wasm-bytecode@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.1"
   checksum: eac400113127832c88f5826bcc3ad1c0db9b3dbd4c51a723cfdb16af6bfcbceb608170fdaac0ab7731a7e18b291be7af68a47fcdb41cfe0260c10857e7413d97
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-bytecode@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.6"
+  checksum: 3535ef4f1fba38de3475e383b3980f4bbf3de72bbb631c2b6584c7df45be4eccd62c6ff48b5edd3f1bcff275cfd605a37679ec199fc91fd0a7705d7f1e3972dc
   languageName: node
   linkType: hard
 
@@ -5137,12 +5329,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-wasm-section@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.6
+    "@webassemblyjs/helper-buffer": 1.11.6
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.6
+    "@webassemblyjs/wasm-gen": 1.11.6
+  checksum: b2cf751bf4552b5b9999d27bbb7692d0aca75260140195cb58ea6374d7b9c2dc69b61e10b211a0e773f66209c3ddd612137ed66097e3684d7816f854997682e9
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ieee754@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/ieee754@npm:1.11.1"
   dependencies:
     "@xtuc/ieee754": ^1.2.0
   checksum: 23a0ac02a50f244471631802798a816524df17e56b1ef929f0c73e3cde70eaf105a24130105c60aff9d64a24ce3b640dad443d6f86e5967f922943a7115022ec
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/ieee754@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/ieee754@npm:1.11.6"
+  dependencies:
+    "@xtuc/ieee754": ^1.2.0
+  checksum: 13574b8e41f6ca39b700e292d7edf102577db5650fe8add7066a320aa4b7a7c09a5056feccac7a74eb68c10dea9546d4461412af351f13f6b24b5f32379b49de
   languageName: node
   linkType: hard
 
@@ -5155,10 +5368,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/leb128@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/leb128@npm:1.11.6"
+  dependencies:
+    "@xtuc/long": 4.2.2
+  checksum: 7ea942dc9777d4b18a5ebfa3a937b30ae9e1d2ce1fee637583ed7f376334dd1d4274f813d2e250056cca803e0952def4b954913f1a3c9068bcd4ab4ee5143bf0
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/utf8@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/utf8@npm:1.11.1"
   checksum: 972c5cfc769d7af79313a6bfb96517253a270a4bf0c33ba486aa43cac43917184fb35e51dfc9e6b5601548cd5931479a42e42c89a13bb591ffabebf30c8a6a0b
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/utf8@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/utf8@npm:1.11.6"
+  checksum: 807fe5b5ce10c390cfdd93e0fb92abda8aebabb5199980681e7c3743ee3306a75729bcd1e56a3903980e96c885ee53ef901fcbaac8efdfa480f9c0dae1d08713
   languageName: node
   linkType: hard
 
@@ -5178,6 +5407,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wasm-edit@npm:^1.11.5":
+  version: 1.11.6
+  resolution: "@webassemblyjs/wasm-edit@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.6
+    "@webassemblyjs/helper-buffer": 1.11.6
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.6
+    "@webassemblyjs/helper-wasm-section": 1.11.6
+    "@webassemblyjs/wasm-gen": 1.11.6
+    "@webassemblyjs/wasm-opt": 1.11.6
+    "@webassemblyjs/wasm-parser": 1.11.6
+    "@webassemblyjs/wast-printer": 1.11.6
+  checksum: 29ce75870496d6fad864d815ebb072395a8a3a04dc9c3f4e1ffdc63fc5fa58b1f34304a1117296d8240054cfdbc38aca88e71fb51483cf29ffab0a61ef27b481
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wasm-gen@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/wasm-gen@npm:1.11.1"
@@ -5191,6 +5436,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wasm-gen@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/wasm-gen@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.6
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.6
+    "@webassemblyjs/ieee754": 1.11.6
+    "@webassemblyjs/leb128": 1.11.6
+    "@webassemblyjs/utf8": 1.11.6
+  checksum: a645a2eecbea24833c3260a249704a7f554ef4a94c6000984728e94bb2bc9140a68dfd6fd21d5e0bbb09f6dfc98e083a45760a83ae0417b41a0196ff6d45a23a
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wasm-opt@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/wasm-opt@npm:1.11.1"
@@ -5200,6 +5458,18 @@ __metadata:
     "@webassemblyjs/wasm-gen": 1.11.1
     "@webassemblyjs/wasm-parser": 1.11.1
   checksum: 21586883a20009e2b20feb67bdc451bbc6942252e038aae4c3a08e6f67b6bae0f5f88f20bfc7bd0452db5000bacaf5ab42b98cf9aa034a6c70e9fc616142e1db
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-opt@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/wasm-opt@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.6
+    "@webassemblyjs/helper-buffer": 1.11.6
+    "@webassemblyjs/wasm-gen": 1.11.6
+    "@webassemblyjs/wasm-parser": 1.11.6
+  checksum: b4557f195487f8e97336ddf79f7bef40d788239169aac707f6eaa2fa5fe243557c2d74e550a8e57f2788e70c7ae4e7d32f7be16101afe183d597b747a3bdd528
   languageName: node
   linkType: hard
 
@@ -5217,6 +5487,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wasm-parser@npm:1.11.6, @webassemblyjs/wasm-parser@npm:^1.11.5":
+  version: 1.11.6
+  resolution: "@webassemblyjs/wasm-parser@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.6
+    "@webassemblyjs/helper-api-error": 1.11.6
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.6
+    "@webassemblyjs/ieee754": 1.11.6
+    "@webassemblyjs/leb128": 1.11.6
+    "@webassemblyjs/utf8": 1.11.6
+  checksum: 8200a8d77c15621724a23fdabe58d5571415cda98a7058f542e670ea965dd75499f5e34a48675184947c66f3df23adf55df060312e6d72d57908e3f049620d8a
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wast-printer@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/wast-printer@npm:1.11.1"
@@ -5224,6 +5508,16 @@ __metadata:
     "@webassemblyjs/ast": 1.11.1
     "@xtuc/long": 4.2.2
   checksum: f15ae4c2441b979a3b4fce78f3d83472fb22350c6dc3fd34bfe7c3da108e0b2360718734d961bba20e7716cb8578e964b870da55b035e209e50ec9db0378a3f7
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wast-printer@npm:1.11.6":
+  version: 1.11.6
+  resolution: "@webassemblyjs/wast-printer@npm:1.11.6"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.6
+    "@xtuc/long": 4.2.2
+  checksum: d2fa6a4c427325ec81463e9c809aa6572af6d47f619f3091bf4c4a6fc34f1da3df7caddaac50b8e7a457f8784c62cd58c6311b6cb69b0162ccd8d4c072f79cf8
   languageName: node
   linkType: hard
 
@@ -5369,6 +5663,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-import-assertions@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "acorn-import-assertions@npm:1.9.0"
+  peerDependencies:
+    acorn: ^8
+  checksum: 944fb2659d0845c467066bdcda2e20c05abe3aaf11972116df457ce2627628a81764d800dd55031ba19de513ee0d43bb771bc679cc0eda66dc8b4fade143bc0c
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.1":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -5407,6 +5710,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 4079b67283b94935157698831967642f24a075c52ce3feaaaafe095776dfbe15d86a1b33b1e53860fc0d062ed6c83f4284a5c87c85b9ad51853a01173da6097f
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.8.2":
+  version: 8.9.0
+  resolution: "acorn@npm:8.9.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 25dfb94952386ecfb847e61934de04a4e7c2dc21c2e700fc4e2ef27ce78cb717700c4c4f279cd630bb4774948633c3859fc16063ec8573bda4568e0a312e6744
   languageName: node
   linkType: hard
 
@@ -5737,13 +6049,6 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
-  languageName: node
-  linkType: hard
-
-"array-union@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "array-union@npm:3.0.1"
-  checksum: 47b29f88258e8f37ffb93ddaa327d4308edd950b52943c172b73558afdd3fa74cfd68816ba5aa4b894242cf281fa3c6d0362ae057e4a18bddbaedbe46ebe7112
   languageName: node
   linkType: hard
 
@@ -7483,19 +7788,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:^10.0.0":
-  version: 10.2.4
-  resolution: "copy-webpack-plugin@npm:10.2.4"
+"copy-webpack-plugin@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "copy-webpack-plugin@npm:11.0.0"
   dependencies:
-    fast-glob: ^3.2.7
+    fast-glob: ^3.2.11
     glob-parent: ^6.0.1
-    globby: ^12.0.2
+    globby: ^13.1.1
     normalize-path: ^3.0.0
     schema-utils: ^4.0.0
     serialize-javascript: ^6.0.0
   peerDependencies:
     webpack: ^5.1.0
-  checksum: 87f0f4530ab3e58ec06a7c3182028dfd8cc85b045a0d18c4464caafeae1ed1141c2aad6eae37e100a74a72b69dc48c93af358c07038b7a22f490a678c0ab142e
+  checksum: df4f8743f003a29ee7dd3d9b1789998a3a99051c92afb2ba2203d3dacfa696f4e757b275560fafb8f206e520a0aa78af34b990324a0e36c2326cefdeef3ca82e
   languageName: node
   linkType: hard
 
@@ -8842,6 +9147,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^5.15.0":
+  version: 5.15.0
+  resolution: "enhanced-resolve@npm:5.15.0"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: fbd8cdc9263be71cc737aa8a7d6c57b43d6aa38f6cc75dde6fcd3598a130cc465f979d2f4d01bb3bf475acb43817749c79f8eef9be048683602ca91ab52e4f11
+  languageName: node
+  linkType: hard
+
 "enquirer@npm:^2.3.5":
   version: 2.3.6
   resolution: "enquirer@npm:2.3.6"
@@ -9051,6 +9366,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "es-module-lexer@npm:1.3.0"
+  checksum: 48fd9f504a9d2a894126f75c8b7ccc6273a289983e9b67255f165bfd9ae765d50100218251e94e702ca567826905ea2f7b3b4a0c4d74d3ce99cce3a2a606a238
+  languageName: node
+  linkType: hard
+
 "es-shim-unscopables@npm:^1.0.0":
   version: 1.0.0
   resolution: "es-shim-unscopables@npm:1.0.0"
@@ -9068,239 +9390,6 @@ __metadata:
     is-date-object: ^1.0.1
     is-symbol: ^1.0.2
   checksum: 4ead6671a2c1402619bdd77f3503991232ca15e17e46222b0a41a5d81aebc8740a77822f5b3c965008e631153e9ef0580540007744521e72de8e33599fca2eed
-  languageName: node
-  linkType: hard
-
-"esbuild-android-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-android-64@npm:0.15.16"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-android-arm64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-android-arm64@npm:0.15.16"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-darwin-64@npm:0.15.16"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-arm64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-darwin-arm64@npm:0.15.16"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-freebsd-64@npm:0.15.16"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-arm64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-freebsd-arm64@npm:0.15.16"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-32@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-32@npm:0.15.16"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-64@npm:0.15.16"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-arm64@npm:0.15.16"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-arm@npm:0.15.16"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-mips64le@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-mips64le@npm:0.15.16"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-ppc64le@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-ppc64le@npm:0.15.16"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-riscv64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-riscv64@npm:0.15.16"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-s390x@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-linux-s390x@npm:0.15.16"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"esbuild-loader@npm:^2.20.0":
-  version: 2.20.0
-  resolution: "esbuild-loader@npm:2.20.0"
-  dependencies:
-    esbuild: ^0.15.6
-    joycon: ^3.0.1
-    json5: ^2.2.0
-    loader-utils: ^2.0.0
-    tapable: ^2.2.0
-    webpack-sources: ^2.2.0
-  peerDependencies:
-    webpack: ^4.40.0 || ^5.0.0
-  checksum: 81faee7155b35af1fdef3dffa273a14ec83e56b9efa1efb76cb1eb64964dd738809c147a87ab9d3507de11946eed51fd1ee42d476b2c9654cbda145da0d9479b
-  languageName: node
-  linkType: hard
-
-"esbuild-netbsd-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-netbsd-64@npm:0.15.16"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-openbsd-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-openbsd-64@npm:0.15.16"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-sunos-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-sunos-64@npm:0.15.16"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-32@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-windows-32@npm:0.15.16"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-windows-64@npm:0.15.16"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-arm64@npm:0.15.16":
-  version: 0.15.16
-  resolution: "esbuild-windows-arm64@npm:0.15.16"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.15.6":
-  version: 0.15.16
-  resolution: "esbuild@npm:0.15.16"
-  dependencies:
-    "@esbuild/android-arm": 0.15.16
-    "@esbuild/linux-loong64": 0.15.16
-    esbuild-android-64: 0.15.16
-    esbuild-android-arm64: 0.15.16
-    esbuild-darwin-64: 0.15.16
-    esbuild-darwin-arm64: 0.15.16
-    esbuild-freebsd-64: 0.15.16
-    esbuild-freebsd-arm64: 0.15.16
-    esbuild-linux-32: 0.15.16
-    esbuild-linux-64: 0.15.16
-    esbuild-linux-arm: 0.15.16
-    esbuild-linux-arm64: 0.15.16
-    esbuild-linux-mips64le: 0.15.16
-    esbuild-linux-ppc64le: 0.15.16
-    esbuild-linux-riscv64: 0.15.16
-    esbuild-linux-s390x: 0.15.16
-    esbuild-netbsd-64: 0.15.16
-    esbuild-openbsd-64: 0.15.16
-    esbuild-sunos-64: 0.15.16
-    esbuild-windows-32: 0.15.16
-    esbuild-windows-64: 0.15.16
-    esbuild-windows-arm64: 0.15.16
-  dependenciesMeta:
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    esbuild-android-64:
-      optional: true
-    esbuild-android-arm64:
-      optional: true
-    esbuild-darwin-64:
-      optional: true
-    esbuild-darwin-arm64:
-      optional: true
-    esbuild-freebsd-64:
-      optional: true
-    esbuild-freebsd-arm64:
-      optional: true
-    esbuild-linux-32:
-      optional: true
-    esbuild-linux-64:
-      optional: true
-    esbuild-linux-arm:
-      optional: true
-    esbuild-linux-arm64:
-      optional: true
-    esbuild-linux-mips64le:
-      optional: true
-    esbuild-linux-ppc64le:
-      optional: true
-    esbuild-linux-riscv64:
-      optional: true
-    esbuild-linux-s390x:
-      optional: true
-    esbuild-netbsd-64:
-      optional: true
-    esbuild-openbsd-64:
-      optional: true
-    esbuild-sunos-64:
-      optional: true
-    esbuild-windows-32:
-      optional: true
-    esbuild-windows-64:
-      optional: true
-    esbuild-windows-arm64:
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 6f9262784b115363290cc9aa54692b3b646cd0508364333a609cc7be5ede4d93f91561ae8da48125e077da2e7add5368105486233ac2258f7169b171e8d78564
   languageName: node
   linkType: hard
 
@@ -9791,7 +9880,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.5, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.11":
+  version: 3.3.0
+  resolution: "fast-glob@npm:3.3.0"
+  dependencies:
+    "@nodelib/fs.stat": ^2.0.2
+    "@nodelib/fs.walk": ^1.2.3
+    glob-parent: ^5.1.2
+    merge2: ^1.3.0
+    micromatch: ^4.0.4
+  checksum: 20df62be28eb5426fe8e40e0d05601a63b1daceb7c3d87534afcad91bdcf1e4b1743cf2d5247d6e225b120b46df0b9053a032b2691ba34ee121e033acd81f547
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.2.5, fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -10589,17 +10691,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^12.0.2":
-  version: 12.2.0
-  resolution: "globby@npm:12.2.0"
+"globby@npm:^13.1.1":
+  version: 13.2.1
+  resolution: "globby@npm:13.2.1"
   dependencies:
-    array-union: ^3.0.1
     dir-glob: ^3.0.1
-    fast-glob: ^3.2.7
-    ignore: ^5.1.9
+    fast-glob: ^3.2.11
+    ignore: ^5.2.0
     merge2: ^1.4.1
     slash: ^4.0.0
-  checksum: 2539379a7fff3473d3e7c68b4540ba38f36970f43f760e36e301515d5cb98a0c5736554957d90390906bee632327beb2f9518d1acd6911f61e436db11b0da5b5
+  checksum: cb57ee0e00a4561e66c8aab5d15462982374632da9330d7ec95e18fe6b22afd95ed8fd701b8bbe5fb5bab2c255ca0b9d6150f68f07324ec84a825edec3c8b11d
   languageName: node
   linkType: hard
 
@@ -11238,7 +11339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.4, ignore@npm:^5.1.9, ignore@npm:^5.2.0":
+"ignore@npm:^5.1.4, ignore@npm:^5.2.0":
   version: 5.2.1
   resolution: "ignore@npm:5.2.1"
   checksum: 7251d00cba49fe88c4f3565fadeb4aa726ba38294a9a79ffed542edc47bafd989d4b2ccf65700c5b1b26a1e91dfc7218fb23017937c79216025d5caeec0ee9d5
@@ -12627,13 +12728,6 @@ __metadata:
     "@jimp/types": ^0.16.1
     regenerator-runtime: ^0.13.3
   checksum: e9792e1e4af7b53c0ab13cc8785a9ecf26b2ac6ea621978a1ce6414dec960c6a4a8f2c7ecd4bf845f3a08106f5e2e88fba31c1d918f2839c6685e1522c4ea4e8
-  languageName: node
-  linkType: hard
-
-"joycon@npm:^3.0.1":
-  version: 3.1.1
-  resolution: "joycon@npm:3.1.1"
-  checksum: 8003c9c3fc79c5c7602b1c7e9f7a2df2e9916f046b0dbad862aa589be78c15734d11beb9fe846f5e06138df22cb2ad29961b6a986ba81c4920ce2b15a7f11067
   languageName: node
   linkType: hard
 
@@ -14943,19 +15037,19 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 4.3.1-pre.632
-  resolution: "openmrs@npm:4.3.1-pre.632"
+  version: 5.0.3-pre.857
+  resolution: "openmrs@npm:5.0.3-pre.857"
   dependencies:
-    "@openmrs/esm-app-shell": 4.3.1-pre.632
-    "@openmrs/webpack-config": 4.3.1-pre.632
+    "@openmrs/esm-app-shell": 5.0.3-pre.857
+    "@openmrs/webpack-config": 5.0.3-pre.857
     "@pnpm/npm-conf": ^2.1.0
+    "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
     axios: ^0.21.1
     browserslist-config-openmrs: ^1.0.1
-    copy-webpack-plugin: ^10.0.0
+    copy-webpack-plugin: ^11.0.0
     cssnano: ^5.0.16
     ejs: ^3.1.8
-    esbuild-loader: ^2.20.0
     glob: ^7.1.3
     html-webpack-plugin: ^5.5.0
     inquirer: ^7.3.3
@@ -14965,9 +15059,10 @@ __metadata:
     postcss: ^8.4.6
     postcss-loader: ^6.2.1
     rimraf: ^3.0.2
+    swc-loader: ^0.2.3
     tar: ^6.0.5
-    typescript: ~4.5.2
-    webpack: ^5.75.0
+    typescript: ^4.6.4
+    webpack: ^5.88.0
     webpack-cli: ^4.10.0
     webpack-dev-server: ^4.10.1
     webpack-pwa-manifest: ^4.3.0
@@ -14975,7 +15070,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: dist/cli.js
-  checksum: e07e3af152b539a80dc0a58e0b869340ef51c8acebcb751ad2ce3511d908a90554f82a1a21f3067d31522bf458182298ef901a122d16f1af19f8faf8f80923e2
+  checksum: 1bea746ba0b921d2e94e8a971ce41e1f759681395bfbdf51a31f8b7330c2c9634d9e131d06214ba7162f5b3db8f5d68b13cf7eb0322961463890052c2abe0bb8
   languageName: node
   linkType: hard
 
@@ -17441,6 +17536,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"schema-utils@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "schema-utils@npm:3.3.0"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: ea56971926fac2487f0757da939a871388891bc87c6a82220d125d587b388f1704788f3706e7f63a7b70e49fc2db974c41343528caea60444afd5ce0fe4b85c0
+  languageName: node
+  linkType: hard
+
 "schema-utils@npm:^4.0.0":
   version: 4.0.0
   resolution: "schema-utils@npm:4.0.0"
@@ -17546,6 +17652,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-javascript@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "serialize-javascript@npm:6.0.1"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: 3c4f4cb61d0893b988415bdb67243637333f3f574e9e9cc9a006a2ced0b390b0b3b44aef8d51c951272a9002ec50885eefdc0298891bc27eb2fe7510ea87dc4f
+  languageName: node
+  linkType: hard
+
 "serve-index@npm:^1.9.1":
   version: 1.9.1
   resolution: "serve-index@npm:1.9.1"
@@ -17646,9 +17761,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"single-spa-react@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "single-spa-react@npm:5.0.0"
+"single-spa-react@npm:~5.0.0":
+  version: 5.0.2
+  resolution: "single-spa-react@npm:5.0.2"
   dependencies:
     browserslist-config-single-spa: ^1.0.1
   peerDependencies:
@@ -17660,7 +17775,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 6b3d0c69720eaef494964f36a5c41fc601d80fcb1fead87bd73c9a7c2db53155ac70111626eec7d75260452f2a867c9139c88269900a2e5cb718264db4863ec7
+  checksum: 3c2503384ab27aed7e4f9f5c6a40cf5aae120cae1749244aba12647159354c143ac03669bfc41a43533077c874866b7042dad9463abe253da198da3f200d8fe1
   languageName: node
   linkType: hard
 
@@ -17800,7 +17915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-list-map@npm:^2.0.0, source-list-map@npm:^2.0.1":
+"source-list-map@npm:^2.0.0":
   version: 2.0.1
   resolution: "source-list-map@npm:2.0.1"
   checksum: 806efc6f75e7cd31e4815e7a3aaf75a45c704871ea4075cb2eb49882c6fca28998f44fc5ac91adb6de03b2882ee6fb02f951fdc85e6a22b338c32bfe19557938
@@ -18356,6 +18471,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swc-loader@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "swc-loader@npm:0.2.3"
+  peerDependencies:
+    "@swc/core": ^1.2.147
+    webpack: ">=2"
+  checksum: 010d84d399525c0185d36d62c86c55ae017e7a90046bc8a39be4b7e07526924037868049f6037bc966da98151cb2600934b96a66279b742d3c413a718b427251
+  languageName: node
+  linkType: hard
+
 "swr@npm:^2.0.1":
   version: 2.0.4
   resolution: "swr@npm:2.0.4"
@@ -18542,6 +18667,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"terser-webpack-plugin@npm:^5.3.7":
+  version: 5.3.9
+  resolution: "terser-webpack-plugin@npm:5.3.9"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.17
+    jest-worker: ^27.4.5
+    schema-utils: ^3.1.1
+    serialize-javascript: ^6.0.1
+    terser: ^5.16.8
+  peerDependencies:
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 41705713d6f9cb83287936b21e27c658891c78c4392159f5148b5623f0e8c48559869779619b058382a4c9758e7820ea034695e57dc7c474b4962b79f553bc5f
+  languageName: node
+  linkType: hard
+
 "terser@npm:^5.0.0, terser@npm:^5.10.0, terser@npm:^5.14.1":
   version: 5.16.0
   resolution: "terser@npm:5.16.0"
@@ -18553,6 +18700,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: d035672bd28bd40ff80d83bea6bc6c85bddf41c18060e49c8b36a3aa45a0a6b4a59c6a56bdf52f9d3350587684d664f8ca26656c6084abeb951b85edf34e47ae
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.16.8":
+  version: 5.18.2
+  resolution: "terser@npm:5.18.2"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.3
+    acorn: ^8.8.2
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: 50988412533bfd5a07294df002d772ad5b1277a9d1164dd19c8876a2094ced7b78fcf36cb32122a9a5238ba2597d77178a2385dfc6c4d506622309493f613cf4
   languageName: node
   linkType: hard
 
@@ -19025,13 +19186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.5.2":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
+"typescript@npm:^4.6.4":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
@@ -19045,13 +19206,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.5.2#~builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=f456af"
+"typescript@patch:typescript@^4.6.4#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=f456af"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 858c61fa63f7274ca4aaaffeced854d550bf416cff6e558c4884041b3311fb662f476f167cf5c9f8680c607239797e26a2ee0bcc6467fbc05bfcb218e1c6c671
+  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
   languageName: node
   linkType: hard
 
@@ -19288,18 +19449,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unistore@npm:^3.5.2":
-  version: 3.5.2
-  resolution: "unistore@npm:3.5.2"
-  peerDependenciesMeta:
-    preact:
-      optional: true
-    react:
-      optional: true
-  checksum: 0f7b3301190c7ebe2e5e0b3529f140b28e1de84518285169ee7b54b3e86defee64e9f3a652b59f07aefe5aa1b7d8282474ba342ff491e3ff9023aeb085f50339
-  languageName: node
-  linkType: hard
-
 "universal-user-agent@npm:^6.0.0":
   version: 6.0.0
   resolution: "universal-user-agent@npm:6.0.0"
@@ -19394,7 +19543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0":
+"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:
@@ -19457,6 +19606,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 
@@ -19916,16 +20074,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^2.2.0":
-  version: 2.3.1
-  resolution: "webpack-sources@npm:2.3.1"
-  dependencies:
-    source-list-map: ^2.0.1
-    source-map: ^0.6.1
-  checksum: 6fd67f2274a84c5f51ad89767112ec8b47727134bf0f2ba0cff458c970f18966939a24128bdbddba621cd66eeb2bef0552642a9333cd8e54514f7b2a71776346
-  languageName: node
-  linkType: hard
-
 "webpack-sources@npm:^3.2.3":
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
@@ -19977,21 +20125,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.75.0":
-  version: 5.77.0
-  resolution: "webpack@npm:5.77.0"
+"webpack@npm:^5.88.0":
+  version: 5.88.1
+  resolution: "webpack@npm:5.88.1"
   dependencies:
     "@types/eslint-scope": ^3.7.3
-    "@types/estree": ^0.0.51
-    "@webassemblyjs/ast": 1.11.1
-    "@webassemblyjs/wasm-edit": 1.11.1
-    "@webassemblyjs/wasm-parser": 1.11.1
+    "@types/estree": ^1.0.0
+    "@webassemblyjs/ast": ^1.11.5
+    "@webassemblyjs/wasm-edit": ^1.11.5
+    "@webassemblyjs/wasm-parser": ^1.11.5
     acorn: ^8.7.1
-    acorn-import-assertions: ^1.7.6
+    acorn-import-assertions: ^1.9.0
     browserslist: ^4.14.5
     chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.10.0
-    es-module-lexer: ^0.9.0
+    enhanced-resolve: ^5.15.0
+    es-module-lexer: ^1.2.1
     eslint-scope: 5.1.1
     events: ^3.2.0
     glob-to-regexp: ^0.4.1
@@ -20000,9 +20148,9 @@ __metadata:
     loader-runner: ^4.2.0
     mime-types: ^2.1.27
     neo-async: ^2.6.2
-    schema-utils: ^3.1.0
+    schema-utils: ^3.2.0
     tapable: ^2.1.1
-    terser-webpack-plugin: ^5.1.3
+    terser-webpack-plugin: ^5.3.7
     watchpack: ^2.4.0
     webpack-sources: ^3.2.3
   peerDependenciesMeta:
@@ -20010,7 +20158,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 21341bb72cbbf61dfb3af91eabe9290a6c05139f268eff3c419e5339deb6c79f2f36de55d9abf017d3ccbad290a535c02325001b2816acc393f3c022e67ac17c
+  checksum: 726e7e05ab2e7c142609a673dd6aa1a711ed97f349418a2a393d650c5ddad172d191257f60e1e37f6b2a77261571c202aabd5ce9240791a686774f0801cf5ec2
   languageName: node
   linkType: hard
 
@@ -20226,12 +20374,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-background-sync@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-background-sync@npm:6.6.0"
+  dependencies:
+    idb: ^7.0.1
+    workbox-core: 6.6.0
+  checksum: ac2990110643aef62ca0be54e962296de7b09593b0262bd09fe4893978a42fa1f256c6d989ed472a31ae500b2255b80c6678530a6024eafb0b2f3a93a3c94a5f
+  languageName: node
+  linkType: hard
+
 "workbox-broadcast-update@npm:6.5.4":
   version: 6.5.4
   resolution: "workbox-broadcast-update@npm:6.5.4"
   dependencies:
     workbox-core: 6.5.4
   checksum: 63cbab2012456871ffeae401e10b16668a0654fa3fa311743cf14e05b8719b797ac3afb47dc8955d87e24f0f1199a547b090bcfdbddd67191b07697d24ac5746
+  languageName: node
+  linkType: hard
+
+"workbox-broadcast-update@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-broadcast-update@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+  checksum: 46a74b3b703244eb363e1731a2d6fe1fb2cd9b82d454733dfc6941fd35b76a852685f56db92408383ac50d564c2fd4282f0c6c4db60ba9beb5f311ea8f944dc7
   languageName: node
   linkType: hard
 
@@ -20280,12 +20447,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-build@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-build@npm:6.6.0"
+  dependencies:
+    "@apideck/better-ajv-errors": ^0.3.1
+    "@babel/core": ^7.11.1
+    "@babel/preset-env": ^7.11.0
+    "@babel/runtime": ^7.11.2
+    "@rollup/plugin-babel": ^5.2.0
+    "@rollup/plugin-node-resolve": ^11.2.1
+    "@rollup/plugin-replace": ^2.4.1
+    "@surma/rollup-plugin-off-main-thread": ^2.2.3
+    ajv: ^8.6.0
+    common-tags: ^1.8.0
+    fast-json-stable-stringify: ^2.1.0
+    fs-extra: ^9.0.1
+    glob: ^7.1.6
+    lodash: ^4.17.20
+    pretty-bytes: ^5.3.0
+    rollup: ^2.43.1
+    rollup-plugin-terser: ^7.0.0
+    source-map: ^0.8.0-beta.0
+    stringify-object: ^3.3.0
+    strip-comments: ^2.0.1
+    tempy: ^0.6.0
+    upath: ^1.2.0
+    workbox-background-sync: 6.6.0
+    workbox-broadcast-update: 6.6.0
+    workbox-cacheable-response: 6.6.0
+    workbox-core: 6.6.0
+    workbox-expiration: 6.6.0
+    workbox-google-analytics: 6.6.0
+    workbox-navigation-preload: 6.6.0
+    workbox-precaching: 6.6.0
+    workbox-range-requests: 6.6.0
+    workbox-recipes: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+    workbox-streams: 6.6.0
+    workbox-sw: 6.6.0
+    workbox-window: 6.6.0
+  checksum: cd1a6c413659c2fd66f4438012f65b211cc748bb594c79bf0d9a60de0cefff3f8a4a23ab06f32c62064c37397ffffc1b77d3328658b7556ea7ff88e57f6ee4fd
+  languageName: node
+  linkType: hard
+
 "workbox-cacheable-response@npm:6.5.4":
   version: 6.5.4
   resolution: "workbox-cacheable-response@npm:6.5.4"
   dependencies:
     workbox-core: 6.5.4
   checksum: f7545b71c1505d6f56f4ba1191989ea7af7119e67fa4eb414d80603221acd0fa31362014106c1df9b9ea0e28bdcf1e2b440859acab06a75e38e978a0d1c2e489
+  languageName: node
+  linkType: hard
+
+"workbox-cacheable-response@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-cacheable-response@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+  checksum: 9e4e00c53679fd2020874cbdf54bb17560fd12353120ea08ca6213e5a11bf08139072616d79f5f8ab80d09f00efde94b003fe9bf5b6e23815be30d7aca760835
   languageName: node
   linkType: hard
 
@@ -20296,6 +20517,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-core@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-core@npm:6.6.0"
+  checksum: 7d773a866b73a733780c52b895f9cf7bec926c9187395c307174deefba9a0a2fcd1edce0d1ca12b8a6c95ca9cf7755ccc1885b03bc82ebcfc4843e015bd84d7b
+  languageName: node
+  linkType: hard
+
 "workbox-expiration@npm:6.5.4":
   version: 6.5.4
   resolution: "workbox-expiration@npm:6.5.4"
@@ -20303,6 +20531,16 @@ __metadata:
     idb: ^7.0.1
     workbox-core: 6.5.4
   checksum: 4b012b69ceafeb5afb3dd6c5c9abe6d55f2eb70666ab603bd78ff839f602336e7493990f729d507ded1fa505b852a5f9135f63afb75b9554c8f948e571143fce
+  languageName: node
+  linkType: hard
+
+"workbox-expiration@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-expiration@npm:6.6.0"
+  dependencies:
+    idb: ^7.0.1
+    workbox-core: 6.6.0
+  checksum: b100b9c512754bc3e1a9c7c7d20d215d72c601a7b956333ca7753704a771a9f00e1732e9b774da4549bae390dd3cd138c6392f6a25fd67f7dcd84f89b0df7e9c
   languageName: node
   linkType: hard
 
@@ -20318,12 +20556,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-google-analytics@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-google-analytics@npm:6.6.0"
+  dependencies:
+    workbox-background-sync: 6.6.0
+    workbox-core: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+  checksum: 7b287da7517ae416aae8ea1494830bb517a29ab9786b2a8b8bf98971377b83715070e784399065ab101d4bba381ab0abbb8bd0962b3010bc01f54fdafb0b6702
+  languageName: node
+  linkType: hard
+
 "workbox-navigation-preload@npm:6.5.4":
   version: 6.5.4
   resolution: "workbox-navigation-preload@npm:6.5.4"
   dependencies:
     workbox-core: 6.5.4
   checksum: c8c341b799f328bb294de8eb9e331a55501d495153237e4ddbaa08bf8630efa700621df5d81f08fb9bffc0f40ecd191a60581f72a3cd5cc72ed2e5baa318c63a
+  languageName: node
+  linkType: hard
+
+"workbox-navigation-preload@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-navigation-preload@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+  checksum: d254465648e45ec6b6d7c3471354336501901d3872622ea9ba1aa1f935d4d52941d0f92fa6c06e7363e10dbac4874d5d4bff7d99cbe094925046f562a37e88cc
   languageName: node
   linkType: hard
 
@@ -20338,12 +20597,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-precaching@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-precaching@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+  checksum: 62e5ee2e40568a56d4131bba461623579f56b9bd273aa7d2805e43151057f413c2ef32fb3d007aff0a5ac3ad84d5feae87408284249a487a5d51c3775c46c816
+  languageName: node
+  linkType: hard
+
 "workbox-range-requests@npm:6.5.4":
   version: 6.5.4
   resolution: "workbox-range-requests@npm:6.5.4"
   dependencies:
     workbox-core: 6.5.4
   checksum: 50f144ced7af7db77b3c64c06c0f9924db5b8573ff2c50b3899fc22c4a360baaf6b332e65f47cf812adfc9dec882a94556fed1cf90ae4ef20b645caa03d1149e
+  languageName: node
+  linkType: hard
+
+"workbox-range-requests@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-range-requests@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+  checksum: a55d1a364b2155548695dc8f6f85baade196d7d1bec980bcdbda80236803b14167995a81b944cffe932a94c4d556466773121afe3661a6f0a13403cbe96d8d9f
   languageName: node
   linkType: hard
 
@@ -20361,6 +20640,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-recipes@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-recipes@npm:6.6.0"
+  dependencies:
+    workbox-cacheable-response: 6.6.0
+    workbox-core: 6.6.0
+    workbox-expiration: 6.6.0
+    workbox-precaching: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+  checksum: f2ecf38502260703e4b0dcef67e3ac26d615f2c90f6d863ca7308db52454f67934ba842fd577ee807d9f510f1a277fd66af7caf57d39e50a181d05dbb3e550a7
+  languageName: node
+  linkType: hard
+
 "workbox-routing@npm:6.5.4, workbox-routing@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-routing@npm:6.5.4"
@@ -20370,12 +20663,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-routing@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-routing@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+  checksum: 7a70b836196eb67332d33a94c0b57859781fe869e81a9c95452d3f4f368d3199f8c3da632dbc10425fde902a1930cf8cfd83f6434ad2b586904ce68cd9f35c6d
+  languageName: node
+  linkType: hard
+
 "workbox-strategies@npm:6.5.4, workbox-strategies@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-strategies@npm:6.5.4"
   dependencies:
     workbox-core: 6.5.4
   checksum: 52134ecd6c05f4edd31e7b022b33a91b7b59c215bfdfb987bc0f10be02fea4d4e6385a9638a2303ba336190c5d28f9721182cd78a6779b9c817a66ec12cb1c6b
+  languageName: node
+  linkType: hard
+
+"workbox-strategies@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-strategies@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+  checksum: 236232a77fb4a4847d1e9ae6c7c9bd9c6b9449209baab9d8d90f78240326a9c0f69551b408ebf9e76610d86da15563bf27439b7e885a7bac01dfd08047c0dd7b
   languageName: node
   linkType: hard
 
@@ -20389,10 +20700,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-streams@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-streams@npm:6.6.0"
+  dependencies:
+    workbox-core: 6.6.0
+    workbox-routing: 6.6.0
+  checksum: 64a295e48e44e3fa4743b5baec646fc9117428e7592033475e38c461e45c294910712f322c32417d354b22999902ef8035119e070e61e159e531d878d991fc33
+  languageName: node
+  linkType: hard
+
 "workbox-sw@npm:6.5.4":
   version: 6.5.4
   resolution: "workbox-sw@npm:6.5.4"
   checksum: b95c76a74b84ff268ef7691447125697f4de85b076ebc33c9545fb7532b020b6f66b37f7a4bedbc21ab45473d1109337a5f037c45b3d99126ae8f5eeb898a687
+  languageName: node
+  linkType: hard
+
+"workbox-sw@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-sw@npm:6.6.0"
+  checksum: bb5f8695de02f89c7955465dcbd568299915565008dc8a068c5d19c1347f75d417640b9f61590e16b169b703e77d02f8b1e10c4b241f74f43cfe76175bfa5fed
+  languageName: node
+  linkType: hard
+
+"workbox-webpack-plugin@npm:^6.1.5":
+  version: 6.6.0
+  resolution: "workbox-webpack-plugin@npm:6.6.0"
+  dependencies:
+    fast-json-stable-stringify: ^2.1.0
+    pretty-bytes: ^5.4.1
+    upath: ^1.2.0
+    webpack-sources: ^1.4.3
+    workbox-build: 6.6.0
+  peerDependencies:
+    webpack: ^4.4.0 || ^5.9.0
+  checksum: b8e04a342f2d45086f28ae56e4806d74dd153c3b750855533a55954f4e85752113e76a6d79a32206eb697a342725897834c9e7976894374d8698cd950477d37a
   languageName: node
   linkType: hard
 
@@ -20418,6 +20761,16 @@ __metadata:
     "@types/trusted-types": ^2.0.2
     workbox-core: 6.5.4
   checksum: bc43c8d31908ab564d740eb1041180c0b0ca4d1f0a3ccde59c5764a8f96d7b08edb7df975360fd37c2bec9f3f57ca9de6c7e34fd252aa1a4a075b5b002f74f60
+  languageName: node
+  linkType: hard
+
+"workbox-window@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-window@npm:6.6.0"
+  dependencies:
+    "@types/trusted-types": ^2.0.2
+    workbox-core: 6.6.0
+  checksum: bb1dd031c1525317ceffbdc3e4f502a70dce461fd6355146e1050c1090f3c640bf65edf42a5d2a3b91b4d0c313df32c1405d88bf701d44c0e3ebc492cd77fe14
   languageName: node
   linkType: hard
 
@@ -20696,5 +21049,22 @@ __metadata:
     synchronous-promise: ^2.0.13
     toposort: ^2.0.2
   checksum: ec7297457ed8a8ccbd7751c4f312a6e651fa5eeb62338d59c6c972f2e6f91d0ce9c7c4026c654afd7bf9fb5b3b651759d5ff5e6621562383390b366048edb5be
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.3.6":
+  version: 4.3.8
+  resolution: "zustand@npm:4.3.8"
+  dependencies:
+    use-sync-external-store: 1.2.0
+  peerDependencies:
+    immer: ">=9.0"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 24db6bf063ce1fc8b2ee238f13211a88f43236541a716e5f6f706f613c671a45332465f9ed06d694f8c353da3d24c53ea668e5712a86aceda9ad74f6c433e8c0
   languageName: node
   linkType: hard


### PR DESCRIPTION
V5 Migration Checklist
- [x] Update Dependencies
- [ ] Migrate Packages - Translate `pages` and `extensions` from `index.ts` to `routes.json`
   - [x] OHRI Core
   - [ ] HIV esm
   - [ ] COVID esm
   - [ ] Cervical Cancer
   - [x] Form Render
   - [x] PMTCT
   - [x] Commons lib
 
House Keeping Checklist
- [x] Replace deprecated `extensionSlotName` with `name`
- [x] Bump version from `1.x` to `2.x`
- [ ] delete redundant dependencies file from esms
