### PR TITLE
OHRI-1555: Remove timeline from the MNCH Infant's Summary

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/views/mch-summary/mch-summary.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/mch-summary/mch-summary.component.tsx
@@ -45,14 +45,10 @@ const MaternalSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
             <Tabs>
               <TabList contained>
                 <Tab>{t('hivExposedInfant', 'HIV Exposed infant')}</Tab>
-                <Tab>{t('timeline', 'Timeline')}</Tab>
               </TabList>
               <TabPanels>
                 <TabPanel>
                   <HivExposedInfant patientUuid={patientUuid} dateOfBirth={dob} />
-                </TabPanel>
-                <TabPanel>
-                  <Timeline patientUuid={patientUuid} />
                 </TabPanel>
               </TabPanels>
             </Tabs>


### PR DESCRIPTION
PTracker
'timeline' removed from the MNCH Infant's Summary
![image](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/130601439/933b385d-4ea1-40a3-ab5b-b31d7db15763)

![image](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/130601439/af841093-8d78-40e7-8e23-6e2f3ba3b0bb)

