### PR TITLE
OHRI-1600: Action buttons for Visit section to work on the previous pregnancies

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/views/mch-summary/tabs/previous-pregnancies.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/mch-summary/tabs/previous-pregnancies.component.tsx
@@ -80,14 +80,14 @@ const PreviousPregnancies: React.FC<PatientChartProps> = ({ patientUuid }) => {
         header: t('actions', 'Actions'),
         getValue: (encounter) => [
           {
-            form: { name: 'labour_and_delivery', package: 'maternal_health' },
+            form: { name: 'Labour & Delivery Form', package: 'maternal_health' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('viewDetails', 'View details'),
             mode: 'view',
           },
           {
-            form: { name: 'labour_and_delivery', package: 'maternal_health' },
+            form: { name: 'Labour & Delivery Form', package: 'maternal_health' },
             encounterUuid: encounter.uuid,
             intent: '*',
             label: t('editForm', 'Edit form'),
@@ -104,7 +104,7 @@ const PreviousPregnancies: React.FC<PatientChartProps> = ({ patientUuid }) => {
       patientUuid={patientUuid}
       encounterType={labourAndDeliveryEncounterType}
       // TODO: replace with form name as configured in the backend.
-      formList={[{ name: 'labour_and_delivery' }]}
+      formList={[{ name: 'Labour & Delivery Form' }]}
       columns={columns}
       description={headerTitle}
       headerTitle={headerTitle}


### PR DESCRIPTION
Action buttons for Visit section to work on the previous pregnancies
![image](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/130601439/d6a88873-d33c-40ed-9837-c8c0ef4c7fb1)
