### PR TITLE
Fix issue with loading links under the programs section

### DIFF
--- a/packages/esm-ohri-core-app/src/ohri-dashboard/ohri-dashboard.component.tsx
+++ b/packages/esm-ohri-core-app/src/ohri-dashboard/ohri-dashboard.component.tsx
@@ -6,8 +6,8 @@ import { useParams } from 'react-router-dom';
 const OHRIDashboard = () => {
   const { view } = useParams();
   const [dashboards, setDashboards] = useState([]);
-  const metaLinks = useExtensionSlotMeta('dashboard-links-slot');
-  const metaFolders = useExtensionSlotMeta('dashboard-slot');
+  const metaLinks = useExtensionSlotMeta('dashboard-links-slot') as Record<string, any>;
+  const metaFolders = useExtensionSlotMeta('dashboard-slot') as Record<string, any>;
   const [currentDashboard, setCurrentDashboard] = useState(null);
   const layout = useLayoutType();
 
@@ -27,11 +27,15 @@ const OHRIDashboard = () => {
   }, [layout]);
 
   useEffect(() => {
-    const linksWithDashboardMeta = Object.values(metaLinks).filter((link) => Object.keys(link).length);
+    const programSpecificLinks = metaFolders ? Object.values(metaFolders).filter((link) => link.isLink) : [];
+    const linksWithDashboardMeta = [
+      ...Object.values(metaLinks).filter((link) => Object.keys(link).length),
+      ...programSpecificLinks,
+    ];
     if (linksWithDashboardMeta.length) {
       setDashboards([...dashboards, ...linksWithDashboardMeta]);
     }
-  }, [metaLinks]);
+  }, [metaLinks, metaFolders]);
 
   const state = useMemo(() => {
     if (currentDashboard) {

--- a/packages/esm-ohri-core-app/src/routes.json
+++ b/packages/esm-ohri-core-app/src/routes.json
@@ -20,7 +20,7 @@
       "component": "homeDashboard",
       "meta": {
         "title": "Home",
-        "path": "home",
+        "name": "home",
         "slot": "ohri-home-dashboard-slot",
         "isLink": true
       }


### PR DESCRIPTION
This PR fixes:
- The Home Dashboard (OHRI-1593)
- Loading isolated dashboards (dbs that are associated with any folders) at index 0 under the programs section.

Attachments:
![2023-07-07 19-02-37 2023-07-07 19_03_39](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/26084581/7b144d94-a33b-4b9b-bc7e-c15e82970cc3)


