### PR TITLE
OHRI-1440 fixes to active link on patient chart with custom functions

### DIFF
--- a/packages/esm-commons-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-commons-lib/src/dashboards/DashboardExtension.tsx
@@ -2,26 +2,33 @@ import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import last from 'lodash-es/last';
 import { ConfigurableLink } from '@openmrs/esm-framework';
-import styles from './dashboardextension.scss';
+import { useTranslation } from 'react-i18next';
 
 export interface DashboardExtensionProps {
   path: string;
   title: string;
   basePath: string;
+  moduleName?: string;
   linkText?: string;
 }
 
-export const DashboardExtension = ({ path, title, basePath, linkText }: DashboardExtensionProps) => {
-  const location = window.location ?? { pathname: '' };
+export const DashboardExtension = ({
+  path,
+  title,
+  basePath,
+  linkText,
+  moduleName = '@openmrs/esm-patient-chart-app',
+}: DashboardExtensionProps) => {
+  const { t } = useTranslation(moduleName);
+  const location = useLocation();
   const navLink = useMemo(() => decodeURIComponent(last(location.pathname.split('/'))), [location.pathname]);
-  const activeClassName = linkText === navLink ? 'active-left-nav-link' : 'non-active'; // add condition if title or linkText
 
   return (
-    <div key={path} className={activeClassName}>
+    <div key={path}>
       <ConfigurableLink
         to={`${basePath}/${encodeURIComponent(path)}`}
-        className={`cds--side-nav__link ${path === navLink && 'active-left-nav-link'} ${styles.link}`}>
-        {linkText || title}
+        className={`cds--side-nav__link ${path === navLink && 'active-left-nav-link'}`}>
+        {linkText || t(title)}
       </ConfigurableLink>
     </div>
   );

--- a/packages/esm-commons-lib/src/dashboards/createDashboard.tsx
+++ b/packages/esm-commons-lib/src/dashboards/createDashboard.tsx
@@ -5,22 +5,12 @@ import { DashboardLinkConfig } from '../types';
 import { DashboardExtension } from './DashboardExtension';
 import { BrowserRouter } from 'react-router-dom';
 
-export const createDashboardLinkWithCustomTitle = (db: DashboardLinkConfig) => {
-  return ({ basePath }: { basePath: string }) => {
-    return (
-      <BrowserRouter>
-        <DashboardExtension path={db.path} title={db.title} basePath={basePath} linkText={db.linkText} />
-      </BrowserRouter>
-    );
-  };
-};
-
 export const createConditionalDashboardLink = (db: DashboardLinkConfig) => {
   return ({ basePath }: { basePath: string }) => {
     return (
       <PatientExtensionRenderer patientExpression={db.patientExpression}>
         <BrowserRouter>
-          <DashboardExtension path={db.path} title={db.title} basePath={basePath} linkText={db.linkText} />
+          <DashboardExtension basePath={basePath} title={db.title} path={db.path} moduleName={db.moduleName} />
         </BrowserRouter>
       </PatientExtensionRenderer>
     );

--- a/packages/esm-commons-lib/src/dashboards/dashboardextension.scss
+++ b/packages/esm-commons-lib/src/dashboards/dashboardextension.scss
@@ -1,6 +1,0 @@
-@import "~@openmrs/esm-styleguide/src/vars";
-
-:global(.active-left-nav-link) .link:nth-child(1) {
-  color: $ui-05;
-  padding: 1.2rem 0 1.2rem 1.2rem;
-}

--- a/packages/esm-commons-lib/src/types/index.ts
+++ b/packages/esm-commons-lib/src/types/index.ts
@@ -1,8 +1,15 @@
 export interface DashboardLinkConfig {
   path: string;
   title: string;
-  linkText?: string;
+  moduleName: string;
   patientExpression?: string;
+}
+
+export interface DashboardConfig extends DashboardLinkConfig {
+  slot: string;
+  config: {
+    columns: number;
+  };
 }
 
 export interface PatientChartProps {

--- a/packages/esm-ohri-pmtct-app/src/dashboard.meta.tsx
+++ b/packages/esm-ohri-pmtct-app/src/dashboard.meta.tsx
@@ -7,11 +7,11 @@ export const mchFolderMeta = {
 };
 
 export const mchSummaryDashboardMeta = {
+  name: 'mch-summary',
   slot: 'mch-summary-slot',
   columns: 1,
-  title: 'Client Summary',
+  title: 'MNCH Summary',
   path: 'mnch-summary',
-  linkText: 'MNCH Summary',
 };
 
 export const maternalVisitsDashboardMeta = {

--- a/packages/esm-ohri-pmtct-app/src/index.ts
+++ b/packages/esm-ohri-pmtct-app/src/index.ts
@@ -6,11 +6,10 @@ import {
   motherChildDashboardMeta,
   mchFolderMeta,
 } from './dashboard.meta';
-import { createDashboardGroup } from '@openmrs/esm-patient-common-lib';
+import { createDashboardGroup, createDashboardLink } from '@openmrs/esm-patient-common-lib';
 import { registerPostSubmissionAction } from '@openmrs/openmrs-form-engine-lib';
 import {
   createConditionalDashboardLink,
-  createDashboardLinkWithCustomTitle,
   createOHRIDashboardLink,
   OHRIHome,
   OHRIWelcomeSection,
@@ -29,6 +28,7 @@ const options = {
 
 export function startupApp() {
   defineConfigSchema(moduleName, {});
+
   registerPostSubmissionAction({
     id: 'MotherToChildLinkageSubmissionAction',
     load: () => import('./post-submission-actions/mother-child-linkage-action'),
@@ -45,7 +45,7 @@ export function startupApp() {
 
 export const mchDashboard = getSyncLifecycle(createDashboardGroup(mchFolderMeta), options);
 export const mchSummaryDashboardLink = getSyncLifecycle(
-  createDashboardLinkWithCustomTitle(mchSummaryDashboardMeta),
+  createDashboardLink({ ...mchSummaryDashboardMeta, moduleName }),
   options,
 );
 export const mchSummaryDashboard = getAsyncLifecycle(() => import('./views/mch-summary/mch-summary.component'), {
@@ -54,7 +54,7 @@ export const mchSummaryDashboard = getAsyncLifecycle(() => import('./views/mch-s
 });
 
 export const maternalVisitsDashboardLink = getSyncLifecycle(
-  createConditionalDashboardLink(maternalVisitsDashboardMeta),
+  createConditionalDashboardLink({ ...maternalVisitsDashboardMeta, moduleName }),
   options,
 );
 export const maternalVisitsDashboard = getAsyncLifecycle(
@@ -66,7 +66,7 @@ export const maternalVisitsDashboard = getAsyncLifecycle(
 );
 
 export const childVisitsDashboardLink = getSyncLifecycle(
-  createConditionalDashboardLink(childVisitsDashboardMeta),
+  createConditionalDashboardLink({ ...childVisitsDashboardMeta, moduleName }),
   options,
 );
 export const childVisitsDashboard = getAsyncLifecycle(() => import('./views/child-health/child-health.component'), {

--- a/packages/esm-ohri-pmtct-app/src/routes.json
+++ b/packages/esm-ohri-pmtct-app/src/routes.json
@@ -25,7 +25,10 @@
     {
       "name": "mch-summary-ext",
       "slot": "mch-summary-slot",
-      "component": "mchSummaryDashboard"
+      "component": "mchSummaryDashboard",
+      "meta": {
+        "title" : "Client Summary"
+      }
     },
     {
       "name": "maternal-visits-dashboard",


### PR DESCRIPTION
The issue with this was because of the discrepancy between how the patient chart functions were working vs how our custom functions were working. Issue was only happening with PMTCT because those are the only places with the custom functions;

- There's no need for the `createDashboardLinkWithCustomTitle` anymore so i deleted it
- Introduced `moduleName` to match patient chart spec

![Screenshot 2023-08-10 at 10 03 11](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/15266028/a1f1466a-c433-445c-b879-6d3cc9dea540)

![Screenshot 2023-08-10 at 10 03 26](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/15266028/182df53a-0b87-41ba-a56e-60092d013349)

