### PR TITLE
(feat) add helper function to auto generate infant ptracker id

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/index.ts
+++ b/packages/esm-ohri-pmtct-app/src/index.ts
@@ -7,13 +7,14 @@ import {
   mchFolderMeta,
 } from './dashboard.meta';
 import { createDashboardGroup, createDashboardLink } from '@openmrs/esm-patient-common-lib';
-import { registerPostSubmissionAction } from '@openmrs/openmrs-form-engine-lib';
+import { registerPostSubmissionAction, registerExpressionHelper } from '@openmrs/openmrs-form-engine-lib';
 import {
   createConditionalDashboardLink,
   createOHRIDashboardLink,
   OHRIHome,
   OHRIWelcomeSection,
 } from '@ohri/openmrs-esm-ohri-commons-lib';
+import { generateInfantPTrackerId } from './utils/ptracker-forms-helpers';
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
@@ -59,6 +60,10 @@ export function startupApp() {
     name: 'ArtSubmissionAction',
     load: () => import('./post-submission-actions/art-linkage-action'),
   });
+  registerExpressionHelper(
+    "customGenerateInfantPTrackerId",
+    generateInfantPTrackerId
+  );
 }
 
 export const mchDashboard = getSyncLifecycle(createDashboardGroup(mchFolderMeta), options);

--- a/packages/esm-ohri-pmtct-app/src/utils/ptracker-forms-helpers.ts
+++ b/packages/esm-ohri-pmtct-app/src/utils/ptracker-forms-helpers.ts
@@ -1,0 +1,11 @@
+export const generateInfantPTrackerId = (
+    fieldId: string,
+    motherPtrackerId: string
+  ): string | undefined => {
+    if (!fieldId || !motherPtrackerId) return;
+    return fieldId === "infantPtrackerid"
+      ? motherPtrackerId + "1"
+      : fieldId.includes("_")
+      ? motherPtrackerId.concat(fieldId.split("_")[1])
+      : undefined;
+  };


### PR DESCRIPTION
[OHRI-1819](https://ohri.atlassian.net/browse/OHRI-1819): Child(s) PTracker ID in L&D form Validated or autopulated based on the birth count form engine helper function

This PR add support to auto populate the PTRacker ID for the Child in full based on the birth count and the mother’s ID i.e. the system should assign PTracker ID to the babies for baby number 1 mothers' ID and 1 for child 1 and 2 for child 2 and add three for child 3 etc



https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/19629227/4064ddd1-ea76-4514-b11a-7bb10c124344





[OHRI-1819]: https://ohri.atlassian.net/browse/OHRI-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ