### PR TITLE
OHRI-1853: ANC and L&D entries for male clients discontinued

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/dashboard.meta.tsx
+++ b/packages/esm-ohri-pmtct-app/src/dashboard.meta.tsx
@@ -21,7 +21,7 @@ export const maternalVisitsDashboardMeta = {
   title: 'Maternal Visits',
   path: 'maternal-visits',
   layoutMode: 'anchored',
-  patientExpression: 'calculateAge(patient.birthDate) > 10',
+  patientExpression: 'calculateAge(patient.birthDate) > 10 && patient.gender === "female"',
 };
 
 export const childVisitsDashboardMeta = {

--- a/packages/esm-ohri-pmtct-app/src/views/mch-summary/mch-summary.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/mch-summary/mch-summary.component.tsx
@@ -13,6 +13,7 @@ const MaternalSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
   const { patient, isLoading } = usePatient(patientUuid);
   const dob = patient?.birthDate;
   const age = moment().diff(patient?.birthDate, 'years');
+  const gender = patient?.gender;
 
   return (
     <>
@@ -20,7 +21,8 @@ const MaternalSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
         <DataTableSkeleton rowCount={5} />
       ) : (
         <div className={styles.tabContainer}>
-          {age > 10 ? (
+        {age > 10 ? (
+            gender === 'female' ? (
             <Tabs>
               <TabList contained>
                 <Tab>{t('recentPregnancy', 'Recent Pregnancy')}</Tab>
@@ -31,6 +33,9 @@ const MaternalSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
                 </TabPanel>
               </TabPanels>
             </Tabs>
+          ) : (
+          null // Don't render anything for male >10
+           )
           ) : (
             <Tabs>
               <TabList contained>

--- a/packages/esm-ohri-pmtct-app/src/views/mch-summary/mch-summary.component.tsx
+++ b/packages/esm-ohri-pmtct-app/src/views/mch-summary/mch-summary.component.tsx
@@ -21,7 +21,7 @@ const MaternalSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
         <DataTableSkeleton rowCount={5} />
       ) : (
         <div className={styles.tabContainer}>
-        {age > 10 ? (
+          {age > 10 ? (
             gender === 'female' ? (
             <Tabs>
               <TabList contained>


### PR DESCRIPTION
ANC , L&D and PNC entries for male clients discontinued

Options should only be available to male clients for registration and capturing of infant PNC visits.





https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/130601439/ccf779dd-d676-4cc8-a3a0-42ac0057dc77


