### PR TITLE
OHRI-2013 disable form launch action from TB previous cases

### DIFF
--- a/packages/esm-tb-app/src/views/patient-summary/tb-patient-summary.component.tsx
+++ b/packages/esm-tb-app/src/views/patient-summary/tb-patient-summary.component.tsx
@@ -134,26 +134,6 @@ const TBSummaryOverviewList: React.FC<PatientChartProps> = ({ patientUuid }) => 
           return getObsFromEncounter(encounter, config.obsConcepts.outcome);
         },
       },
-      {
-        key: 'actions',
-        header: t('actions', 'Actions'),
-        getValue: (encounter) => [
-          {
-            form: { name: 'TB Case Enrollment Form' },
-            encounterUuid: encounter.uuid,
-            intent: '*',
-            label: t('viewDetails', 'View Details'),
-            mode: 'view',
-          },
-          {
-            form: { name: 'TB Case Enrollment Form' },
-            encounterUuid: encounter.uuid,
-            intent: '*',
-            label: t('editForm', 'Edit Form'),
-            mode: 'edit',
-          },
-        ],
-      },
     ],
     [],
   );
@@ -170,12 +150,13 @@ const TBSummaryOverviewList: React.FC<PatientChartProps> = ({ patientUuid }) => 
       <EncounterList
         patientUuid={patientUuid}
         encounterType={config.encounterTypes.tbProgramEnrollment}
-        formList={[{ name: 'TB Case Enrollment Form' }]}
         columns={previousCasesColumns}
         description={headerPreviousCases}
         headerTitle={headerPreviousCases}
+        formList={[{ name: 'TB Case Enrollment Form' }]}
         launchOptions={{
-          displayText: t('add', 'Add'),
+          hideFormLauncher: true,
+          displayText: '',
           moduleName: moduleName,
         }}
       />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
Previously the TB summary table for TB cases was having call to action. This wasn't meant to be the case because the summary is meant only for viewing and not adding data. 

## Screenshots

Empty State

<img width="1791" alt="Screenshot 2023-12-06 at 15 00 38" src="https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/15266028/6bbf8b95-fc41-4377-a2a0-a1266c24a6a6">


With Data

<img width="1788" alt="Screenshot 2023-12-06 at 15 01 20" src="https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/15266028/b61e49c5-258c-490a-95df-de94f333c9f3">

## Related Issue
Follow up fix for https://ohri.atlassian.net/browse/OHRI-2013


## Other
<!-- Anything not covered above -->
