### PR TITLE
OHRI-2095 Populate the missing appointment date on the TB dashboard summary

### DIFF
--- a/packages/esm-commons-lib/src/components/cohort-patient-list/cohort-patient-list.component.tsx
+++ b/packages/esm-commons-lib/src/components/cohort-patient-list/cohort-patient-list.component.tsx
@@ -286,6 +286,7 @@ export const CohortPatientList: React.FC<CohortPatientListProps> = ({
       autoFocus: true,
     };
   }, [
+    loadedExtraEncounters,
     searchTerm,
     filteredResults,
     paginatedPatients,

--- a/packages/esm-tb-app/src/views/dashboard/patient-list-tabs/tb-patient-list-tabs.component.tsx
+++ b/packages/esm-tb-app/src/views/dashboard/patient-list-tabs/tb-patient-list-tabs.component.tsx
@@ -23,6 +23,7 @@ function TbHomePatientTabs() {
         },
         associatedEncounterType: config.encounterTypes.tbProgramEnrollment,
         excludeColumns: ['timeAddedToList', 'waitingTime', 'location', 'phoneNumber', 'hivResult'],
+        extraAssociatedEncounterTypes: [config.encounterTypes.tbTreatmentAndFollowUp],
         otherColumns: [
           {
             key: 'caseID',
@@ -49,8 +50,14 @@ function TbHomePatientTabs() {
           {
             key: 'nextAppointmentDate',
             header: t('appointmentDate', 'Appointment Date'),
-            getValue: ({ latestEncounter }) => {
-              return getObsFromEncounter(latestEncounter, config.obsConcepts.nextAppointmentDate, true);
+            getValue:  (patient) => {
+              const patientLatestExtraEncounters = patient.latestExtraEncounters
+              if (patientLatestExtraEncounters && patientLatestExtraEncounters.length) {
+                const latestFollowUpEncounter = patientLatestExtraEncounters[0];
+                return getObsFromEncounter(latestFollowUpEncounter, config.obsConcepts.nextAppointmentDate, true);
+              } else {
+                return '--';
+              }
             },
           },
           {

--- a/packages/esm-tb-app/src/views/dashboard/patient-list-tabs/tb-patient-list-tabs.component.tsx
+++ b/packages/esm-tb-app/src/views/dashboard/patient-list-tabs/tb-patient-list-tabs.component.tsx
@@ -50,11 +50,15 @@ function TbHomePatientTabs() {
           {
             key: 'nextAppointmentDate',
             header: t('appointmentDate', 'Appointment Date'),
-            getValue:  (patient) => {
-              const patientLatestExtraEncounters = patient.latestExtraEncounters
+            getValue: (patient) => {
+              const patientLatestExtraEncounters = patient.latestExtraEncounters;
               if (patientLatestExtraEncounters && patientLatestExtraEncounters.length) {
-                const latestFollowUpEncounter = patientLatestExtraEncounters[0];
-                return getObsFromEncounter(latestFollowUpEncounter, config.obsConcepts.nextAppointmentDate, true);
+                const latestFollowUpEncounter = patientLatestExtraEncounters.find(
+                  (encounter) => encounter.encounterType.uuid === config.encounterTypes.tbTreatmentAndFollowUp,
+                );
+                return latestFollowUpEncounter
+                  ? getObsFromEncounter(latestFollowUpEncounter, config.obsConcepts.nextAppointmentDate, true)
+                  : '--';
               } else {
                 return '--';
               }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR populates appointment date  on the TB dashboard summary. In general it also allows the cohort list to pull concepts from more than one encounter type.

## Screenshots

https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/12844964/29fd4b52-b811-4923-a70a-027ad849b744


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://ohri.atlassian.net/browse/OHRI- -->

## Other
<!-- Anything not covered above -->
