### PR TITLE
(chore) remove condition for release on master push

### DIFF
--- a/.github/workflows/node.master.js.yml
+++ b/.github/workflows/node.master.js.yml
@@ -57,7 +57,7 @@ jobs:
 
     needs: build
 
-    if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'release' }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
This removes the condition to publish release on push to master. Release will be limited to creating a new release on github. This will avoid unnecessary release deployments 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://ohri.atlassian.net/browse/OHRI- -->

## Other
<!-- Anything not covered above -->
