### PR TITLE
OHRI-2109: Add TB Prevention link under Tuberculosis program in the clinical perspectives

### DIFF
--- a/packages/esm-tb-app/src/dashboard.meta.tsx
+++ b/packages/esm-tb-app/src/dashboard.meta.tsx
@@ -44,19 +44,18 @@ export const tbClinicalViewDashboardMeta = {
   isFolder: true,
   title: 'Tuberculosis',
 };
+export const tbPreventionDashboardMeta = {
+  name: 'tb-prevention',
+  slot: 'tb-prevention-dashboard-slot',
+  config: { columns: 1, type: 'grid', programme: 'tpt', dashboardTitle: 'TB Prevention'},
+  title: 'TB Prevention',
+};
 
 export const tbCasesDashboardMeta = {
   name: 'tb-cases',
   slot: 'tb-cases-dashboard-slot',
   config: { columns: 1, type: 'grid', programme: 'tb', dashboardTitle: 'TB Treatment' },
   title: 'TB Treatment',
-};
-
-export const tbPreventionDashboardMeta = {
-  name: 'tb-prevention',
-  slot: 'tb-prevention-dashboard-slot',
-  config: { columns: 1, type: 'grid', programme: 'tpt', dashboardTitle: 'TB Prevention'},
-  title: 'TB Prevention',
 };
 
 export const tptPatientChartMeta = {

--- a/packages/esm-tb-app/src/routes.json
+++ b/packages/esm-tb-app/src/routes.json
@@ -153,6 +153,37 @@
       }
     },
     {
+      "name": "tb-prevention-dashboard-ext",
+      "slot": "tb-clinical-dashboard-slot",
+      "component": "tbPreventionDashboardLink",
+      "meta": {
+        "name": "tb-prevention",
+        "slot": "tb-prevention-dashboard-slot",
+        "config": {
+          "columns": 1,
+          "type": "grid",
+          "programme": "tpt",
+          "dashboardTitle": "TB Prevention"
+        },
+        "title": "TB Prevention"
+      }
+    },
+    {
+      "name": "tb-prevention-dashboard",
+      "slot": "tb-prevention-dashboard-slot",
+      "component": "tbPreventionDashboard",
+      "meta": {
+        "name": "tb-prevention",
+        "slot": "tb-prevention-dashboard-slot",
+        "config": {
+          "columns": 1,
+          "programme": "tpt",
+          "dashboardTitle": "TB Prevention"
+        },
+        "title": "TB Prevention"
+      }
+    },
+    {
       "name": "tb-cases-dashboard-ext",
       "slot": "tb-clinical-dashboard-slot",
       "component": "tbCasesDashboardLink",
@@ -197,37 +228,6 @@
       "name": "tb-home-tabs-ext",
       "slot": "tb-home-tabs-slot",
       "component": "tbDashboardTabs"
-    },
-    {
-      "name": "tb-prevention-dashboard-ext",
-      "slot": "tb-clinical-dashboard-slot",
-      "component": "tbPreventionDashboardLink",
-      "meta": {
-        "name": "tb-prevention",
-        "slot": "tb-prevention-dashboard-slot",
-        "config": {
-          "columns": 1,
-          "type": "grid",
-          "programme": "tpt",
-          "dashboardTitle": "TB Prevention"
-        },
-        "title": "TB Prevention"
-      }
-    },
-    {
-      "name": "tb-prevention-dashboard",
-      "slot": "tb-prevention-dashboard-slot",
-      "component": "tbPreventionDashboard",
-      "meta": {
-        "name": "tb-prevention",
-        "slot": "tb-prevention-dashboard-slot",
-        "config": {
-          "columns": 1,
-          "programme": "tpt",
-          "dashboardTitle": "TB Prevention"
-        },
-        "title": "TB Prevention"
-      }
     },
     {
       "name": "tpt-home-header-ext",

--- a/packages/esm-tb-app/translations/en.json
+++ b/packages/esm-tb-app/translations/en.json
@@ -39,6 +39,6 @@
   "tptAdherence": "Adherence",
   "nextAppointmentDate": "Next Appointment Date",
   "previousTptCases":  "Previous TPT Cases",
-  "recentTptCases": "Recent TPT Cases",
+  "recentTptCases": "Recent TPT Cases"
 
 }

--- a/packages/esm-tb-app/translations/en.json
+++ b/packages/esm-tb-app/translations/en.json
@@ -38,8 +38,7 @@
   "indication":  "Indication",
   "tptAdherence": "Adherence",
   "nextAppointmentDate": "Next Appointment Date",
-  "previousCases":  "Previous TPT Cases",
-  "previousTptCases": "Recent TPT Cases",
-  "previousCases": "Previous Cases"
+  "previousTptCases":  "Previous TPT Cases",
+  "recentTptCases": "Recent TPT Cases",
 
 }

--- a/packages/esm-tb-app/translations/en.json
+++ b/packages/esm-tb-app/translations/en.json
@@ -40,7 +40,6 @@
   "nextAppointmentDate": "Next Appointment Date",
   "previousCases":  "Previous TPT Cases",
   "previousTptCases": "Recent TPT Cases",
-  "recentTuberculosis": "Recent Tuberculosis",
   "previousCases": "Previous Cases"
 
 }

--- a/packages/esm-tb-app/translations/en.json
+++ b/packages/esm-tb-app/translations/en.json
@@ -39,6 +39,8 @@
   "tptAdherence": "Adherence",
   "nextAppointmentDate": "Next Appointment Date",
   "previousCases":  "Previous TPT Cases",
-  "previousTptCases": "Recent TPT Cases"
+  "previousTptCases": "Recent TPT Cases",
+  "recentTuberculosis": "Recent Tuberculosis",
+  "previousCases": "Previous Cases"
 
 }


### PR DESCRIPTION

## Requirements

Add TB Prevention link under Tuberculosis program in the clinical perspectives

## Summary
Update--> the TB Prevention link comes first followed by TB Treatment.

## Screenshots
![image](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/130601439/6b9e7abf-0a78-4b59-b0d6-7c0e1593b04b)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://ohri.atlassian.net/browse/OHRI- -->

## Other
<!-- Anything not covered above -->
