### PR TITLE
OHRI-2121 (fix) Load Previous Cases on patient summary

### DIFF
--- a/packages/esm-tb-app/src/views/tpt/patient-summary/patient-summary.component.tsx
+++ b/packages/esm-tb-app/src/views/tpt/patient-summary/patient-summary.component.tsx
@@ -97,7 +97,7 @@ const TptPatientSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
         header: t('indication', 'Indication'),
         encounterTypes: [encounterTypes.tptCaseEnrollment],
         getValue: (encounter) => {
-          return getObsFromEncounter(encounter, obsConcepts.indication);
+          return getObsFromEncounter(encounter, obsConcepts.tptIndication);
         },
       },
       {
@@ -192,7 +192,7 @@ const TptPatientSummary: React.FC<PatientChartProps> = ({ patientUuid }) => {
       />
       <EncounterList
         patientUuid={patientUuid}
-        encounterType={encounterTypes.tbProgramEnrollment}
+        encounterType={encounterTypes.tptCaseEnrollment}
         columns={previousTptCasesColumns}
         description={headerPreviousTptCases}
         headerTitle={headerPreviousTptCases}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
PR fixes an issue where the previous Cases on the TPT patient summary wasn't loading
## Screenshots
![image](https://github.com/UCSF-IGHS/openmrs-esm-ohri/assets/43242517/0414fccb-1f05-44c6-bf00-4fdcc2dce7c8)
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://ohri.atlassian.net/browse/OHRI- -->

## Other
<!-- Anything not covered above -->
