### PR TITLE
(Fix) Refactor TB workflow schema to use config keys not hardcoded uuids.

### DIFF
--- a/packages/esm-tb-app/src/views/patient-summary/previous-cases-config.json
+++ b/packages/esm-tb-app/src/views/patient-summary/previous-cases-config.json
@@ -5,44 +5,44 @@
       "tabName": "Previous Cases",
       "headerTitle": "Previous Cases",
       "displayText": "Previous Cases",
-      "encounterType": "9a199b59-b185-485b-b9b3-a9754e65ae57",
+      "encounterType": "tbProgramEnrollment",
       "columns": [
         {
           "id": "caseID",
           "title": "Case ID",
-          "concept": "162576AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          "concept": "caseID"
         },
         {
           "id": "enrollmentDate",
           "isDate": true,
           "title": "Enrollment Date",
-          "concept": "161552AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          "concept": "enrollmentDate"
         },
         {
           "id": "type",
           "title": "Type",
-          "concept": "159990AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          "concept": "type"
         },
         {
           "id": "site",
           "title": "Site",
-          "concept": "160040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          "concept": "site"
         },
         {
           "id": "regimen",
           "title": "Regimen",
           "isConditionalConcept": true,
           "conditionalConceptMappings": {
-            "trueConcept": "16fd7307-0b26-4c8b-afa3-8362baff4042",
-            "nonTrueConcept": "159909AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-            "dependantConcept": "163775AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-            "conditionalConcept": "160541AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "trueConcept": "dSregimen",
+            "nonTrueConcept": "dRregimen",
+            "dependantConcept": "tBEnrollmentType",
+            "conditionalConcept": "dsTBEnrollment"
           }
         },
         {
           "id": "outcome",
           "title": "Outcome",
-          "concept": "159786AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          "concept": "outcome"
         }
       ],
       "launchOptions": {
@@ -52,8 +52,8 @@
       },
       "formList": [
         {
-          "name": "TB Case Enrollment Form",
-          "uuid": "554b2017-e512-3fc8-9c6e-7baf9e69db9d"
+          "name": "TbCaseEnrolmentFormName",
+          "uuid": "tbCaseEnrolmentFormUuid"
         }
       ]
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR does a small refactor for using config keys instead of hardcoded concept values in TB

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
- https://ohri.atlassian.net/browse/OHRI-2234

## Other
<!-- Anything not covered above -->
