### PR TITLE
(feat) disable Auto opening of Clinical-forms-workspace on form cancellation

### DIFF
--- a/packages/esm-commons-lib/src/components/encounter-list/helpers.ts
+++ b/packages/esm-commons-lib/src/components/encounter-list/helpers.ts
@@ -29,6 +29,7 @@ export function launchEncounterForm(
       additionalProps: {
         mode: action === 'add' ? 'enter' : action,
         formSessionIntent: intent,
+        openClinicalFormsWorkspaceOnFormClose: false,
       },
     },
   });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

Whenever a form is cancelled, the `clinical-forms-workspace `is automatically opened. This however shouldn't be the case if the form wasn't opened from the `clinical-forms-workspace` in the first place. This PR seeks to resolve the issue.

## Screenshots
Before:

https://github.com/user-attachments/assets/ab3f279e-6da9-4eac-b5ad-9a8db1d9b431

After:

https://github.com/user-attachments/assets/af85cc2b-0565-42f0-abaa-35a3ed76525f



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://ohri.atlassian.net/browse/OHRI- -->

## Other
<!-- Anything not covered above -->
