### PR TITLE
Remove redundant PtrackerId and MotherName columns on child visit list

### DIFF
--- a/packages/esm-ohri-pmtct-app/src/pmtct/patient-chart/child-health/child-health-config.json
+++ b/packages/esm-ohri-pmtct-app/src/pmtct/patient-chart/child-health/child-health-config.json
@@ -8,16 +8,6 @@
       "encounterType": "infantPostnatalEncounterType",
       "columns": [
         {
-          "id": "pTrackerId",
-          "title": "PTracker Id",
-          "concept": "pTrackerIdConcept"
-        },
-        {
-          "id": "mothersName",
-          "title": "Mothers Name",
-          "type": "mothersName"
-        },
-        {
           "id": "artProphylaxisStatus",
           "title": "ART Prophylaxis Status",
           "concept": "artProphylaxisStatus"


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
Since Mother Name is already displayed on the child's patient banner, there is no need to display it also on the infant PNC encounter list. Same applies to the PtrackerId that will always stay the same for the child thus creating more space for required variables

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://ohri.atlassian.net/browse/OHRI-2317

## Other
<!-- Anything not covered above -->
