### PR TITLE
(fix): Wrap dashboard title in t function

### DIFF
--- a/packages/esm-commons-lib/src/components/ohri-home/welcome-section/ohri-welcome-section.component.tsx
+++ b/packages/esm-commons-lib/src/components/ohri-home/welcome-section/ohri-welcome-section.component.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Calendar } from '@carbon/react/icons';
 import { useSession } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
 
 import styles from './ohri-welcome-section.scss';
 
@@ -11,13 +12,14 @@ interface OHRIWelcomeSectionProps {
 
 export const OHRIWelcomeSection: React.FC<OHRIWelcomeSectionProps> = ({ title, icon }) => {
   const userSession = useSession();
+  const { t } = useTranslation();
   return (
     <div className={styles.welcomeContainer}>
       <div className={styles.welcomeIcon}>{icon}</div>
       <div className={styles.welcomeDetails}>
         <div className={styles.location}>{userSession?.sessionLocation.display}</div>
         <div className={styles.dashboardDetails}>
-          <div className={styles.dashboardTitle}>{title}</div>
+          <div className={styles.dashboardTitle}>{t(title)}</div>
           <div className={styles.currentDate}>
             <Calendar size={32} className={styles.calendarIcon} />
             {new Date().toLocaleDateString() + ''}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes the ticket number in the format `OHRI-123 My PR title`.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR wraps the dashboard title in the `i18n` `t` function to make it translatable.

## Screenshots
<!-- Required if you are making UI changes. -->
After fix:
<img width="1481" alt="Screenshot 2024-10-27 at 8 22 09 PM" src="https://github.com/user-attachments/assets/0d5718e5-ec8e-4866-a79a-9014396355fa">

Before fix:
<img width="1481" alt="Screenshot 2024-10-27 at 8 28 18 PM" src="https://github.com/user-attachments/assets/02d9fc5d-628e-4b68-be87-c1f64eae94f2">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://ohri.atlassian.net/browse/OHRI- -->

## Other
<!-- Anything not covered above -->
